### PR TITLE
chore: update release skill and docs for protected workflow

### DIFF
--- a/.claude/commands/release.md
+++ b/.claude/commands/release.md
@@ -1,6 +1,11 @@
 Perform a release for this project. Follow every step in order.
 
-## 1. Determine version bump
+## 1. Preflight
+
+- Confirm you are on `main` and it is clean (`git status` shows no changes).
+- Run `npm run lint` and `npm run test` — abort if either fails.
+
+## 2. Determine version bump
 
 Examine commits since the last git tag using conventional commit prefixes:
 - Any `feat:` → **minor**
@@ -11,7 +16,11 @@ If an argument is provided (e.g. `/release patch`), use that as the bump type in
 
 Argument: $ARGUMENTS
 
-## 2. Update CHANGELOG.md
+## 3. Create release branch
+
+Create and check out `release/vX.Y.Z` from `main`.
+
+## 4. Update CHANGELOG.md
 
 - Read the current CHANGELOG.md.
 - Add a new section at the top (below the `# Changelog` heading) for the new version and today's date.
@@ -19,29 +28,39 @@ Argument: $ARGUMENTS
 - Write concise, user-facing descriptions (not raw commit messages).
 - Add a reference link at the bottom of the file matching the existing format.
 
-## 3. Update README.md
+## 5. Update README.md
 
 Read README.md and update any option descriptions, defaults, or behavior notes that are affected by the changes in this release. Only edit what is factually out of date — do not rewrite unrelated sections.
 
-## 4. Bump version
+## 6. Bump version
 
 Run `npm version <major|minor|patch> --no-git-tag-version` to update package.json.
 
-## 5. Build
+## 7. Build
 
 Run `npm run build` and verify it succeeds.
 
-## 6. Commit, tag, and push
+## 8. Commit and push
 
 - Stage all changed files (CHANGELOG.md, README.md, package.json, package-lock.json, dist/).
 - Create a single commit: `chore: release vX.Y.Z`
-- Create git tag `vX.Y.Z`.
-- Push commits and tag to origin.
+- Push the release branch to origin.
 
-## 7. Create GitHub release
+## 9. Open PR
 
-Use `gh release create` with:
-- Title: `vX.Y.Z`
-- Notes: the changelog entry for this version (the content under the new `## [vX.Y.Z]` heading).
+Create a PR from `release/vX.Y.Z` → `main` with:
+- Title: `chore: release vX.Y.Z`
+- Body: the changelog entry for this version
+
+Then **stop and ask the user to review and merge the PR**.
+
+## 10. Tag and create GitHub release
+
+Only proceed after the user confirms the PR is merged.
+
+- Pull `main` to get the squash-merged commit.
+- Create git tag `vX.Y.Z` on `main`.
+- Push the tag to origin.
+- Run `gh release create vX.Y.Z --title "vX.Y.Z" --notes "<changelog entry>"`.
 
 The release workflow will automatically build and attach the JS artifact.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -11,10 +11,12 @@ A standalone custom Home Assistant Lovelace card for displaying NWS (National We
 ```bash
 npm run build     # Rollup bundle → dist/nws-alerts-card.js (single ES module, ~31KB minified)
 npm run watch     # Rollup in watch mode
-npm run lint      # TypeScript type-check (tsc --noEmit), no linter configured
+npm run lint      # TypeScript type-check (tsc --noEmit)
+npm run test      # Vitest unit tests (jsdom environment)
+npm run test:watch # Vitest in watch mode
 ```
 
-Always run `npm run lint` before committing to catch type errors.
+Always run `npm run lint` and `npm run test` before committing.
 
 ## Source Architecture
 
@@ -89,13 +91,21 @@ The card needs the `sensor.nws_alerts_alerts` entity which comes from the [NWS A
 
    **Important**: zone codes must be comma-delimited with **no spaces** (e.g. `COC059,COZ039,COZ239`). Adding spaces after commas (e.g. `COC059, COZ039`) causes the integration to silently return no alerts. Find your zone codes at https://alerts.weather.gov/.
 
+## Workflow
+
+- `main` is protected: all changes go through PRs with required status checks (build, lint, test, HACS validation).
+- Only squash merges are allowed — one commit per PR on `main`.
+- Feature branches: `feat/<name>`, `fix/<name>`, `chore/<name>`, etc.
+- Use the `/release` skill to perform releases (creates a release branch, PR, tag, and GitHub Release).
+
 ## HACS Distribution
 
 - `hacs.json` — HACS manifest (name, filename).
 - `.github/workflows/release.yml` — on GitHub Release publish: builds and attaches `dist/nws-alerts-card.js` to the release.
-- To release:
-  1. Update `CHANGELOG.md` — add a new section at the top with the version, date, and categorized changes (Added, Changed, Fixed, Removed).
-  2. Bump version in `package.json` via `npm version <major|minor|patch> --no-git-tag-version`.
-  3. Run `npm run build`.
-  4. Commit, tag, push, and create a GitHub Release; the workflow attaches the built JS.
+- To release, use the `/release` skill or follow its steps manually:
+  1. Create `release/vX.Y.Z` branch from `main`.
+  2. Update `CHANGELOG.md`, bump version in `package.json`, run `npm run build`.
+  3. Commit, push, and open a PR to `main`.
+  4. After merge: tag `main` as `vX.Y.Z`, push tag, create GitHub Release with `gh release create`.
+  5. The release workflow attaches the built JS artifact.
 - Users add this repo as a HACS custom repository (Frontend category).

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -12,7 +12,7 @@ See [AGENTS.md](AGENTS.md) for full architecture details and dev container instr
 ## Workflow
 
 1. Create a feature branch from `main`
-2. Make changes, run `npm run lint` and `npm run build`
+2. Make changes, run `npm run lint`, `npm run test`, and `npm run build`
 3. Open a PR targeting `main`
 4. PRs are squash-merged after review and passing CI
 
@@ -20,6 +20,7 @@ See [AGENTS.md](AGENTS.md) for full architecture details and dev container instr
 
 All PRs must pass:
 - `npm run lint` — TypeScript type-check
+- `npm run test` — Vitest unit tests
 - `npm run build` — Rollup bundle
 - HACS validation
 


### PR DESCRIPTION
## Summary

- Update `/release` skill to work with branch protection (creates release branch + PR instead of pushing directly to main)
- Add preflight checks (lint + test) to release skill
- Update AGENTS.md and CONTRIBUTING.md with new workflow docs and test commands

## Changes

- `.claude/commands/release.md` — rewritten for PR-based release flow with review pause before tagging
- `AGENTS.md` — add Workflow section, add test commands to Build Commands
- `CONTRIBUTING.md` — add test step to workflow and CI checks

## Test Plan

- [x] `npm run lint` passes
- [x] `npm run test` passes (30/30)
- [x] `npm run build` passes