### PR TITLE
chore: release v1.9.0-alpha.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 All notable changes to this project will be documented in this file.
 
+## [v1.9.0-alpha.2] - 2026-03-06
+
+### Fixed
+
+- Removed `country: US` restriction from HACS manifest so the card is discoverable globally (not just for US-based HA instances)
+
 ## [v1.9.0-alpha.1] - 2026-03-06
 
 ### Added
@@ -121,6 +127,7 @@ All notable changes to this project will be documented in this file.
 - Card picker integration
 - Shadow DOM with full HA theme support
 
+[v1.9.0-alpha.2]: https://github.com/seevee/nws_alerts_card/releases/tag/v1.9.0-alpha.2
 [v1.9.0-alpha.1]: https://github.com/seevee/nws_alerts_card/releases/tag/v1.9.0-alpha.1
 [v1.8.0]: https://github.com/seevee/nws_alerts_card/releases/tag/v1.8.0
 [v1.7.0]: https://github.com/seevee/nws_alerts_card/releases/tag/v1.7.0

--- a/hacs.json
+++ b/hacs.json
@@ -1,6 +1,5 @@
 {
   "name": "NWS Alerts Card",
   "render_readme": true,
-  "filename": "nws-alerts-card.js",
-  "country": "US"
+  "filename": "nws-alerts-card.js"
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "nws-alerts-card",
-  "version": "1.9.0-alpha.1",
+  "version": "1.9.0-alpha.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "nws-alerts-card",
-      "version": "1.9.0-alpha.1",
+      "version": "1.9.0-alpha.2",
       "license": "MIT",
       "dependencies": {
         "custom-card-helpers": "^1.9.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "nws-alerts-card",
-  "version": "1.9.0-alpha.1",
+  "version": "1.9.0-alpha.2",
   "description": "A custom Home Assistant Lovelace card for displaying NWS weather alerts",
   "main": "dist/nws-alerts-card.js",
   "module": "dist/nws-alerts-card.js",


### PR DESCRIPTION
## [v1.9.0-alpha.2] - 2026-03-06

### Fixed

- Removed `country: US` restriction from HACS manifest so the card is discoverable globally (not just for US-based HA instances)