### PR TITLE
fix: use absolute URLs for README images in HACS

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,13 +6,13 @@ A custom Home Assistant Lovelace card for displaying weather alerts with severit
 
 | Light | Dark |
 |:---:|:---:|
-| ![Light mode](img/severity-light-details.png) | ![Dark mode](img/severity-dark-details.png) |
+| ![Light mode](https://raw.githubusercontent.com/seevee/nws_alerts_card/main/img/severity-light-details.png) | ![Dark mode](https://raw.githubusercontent.com/seevee/nws_alerts_card/main/img/severity-dark-details.png) |
 
 **Compact layout** — NWS official colors
 
 | Light | Dark |
 |:---:|:---:|
-| ![Light mode](img/nws-light-compact.png) | ![Dark mode](img/nws-dark-compact.png) |
+| ![Light mode](https://raw.githubusercontent.com/seevee/nws_alerts_card/main/img/nws-light-compact.png) | ![Dark mode](https://raw.githubusercontent.com/seevee/nws_alerts_card/main/img/nws-dark-compact.png) |
 
 ## Features
 


### PR DESCRIPTION
## Summary
- Replace relative image paths (`img/...`) with absolute `raw.githubusercontent.com` URLs in README
- Fixes images not displaying in the HACS store page (relative paths don't resolve outside GitHub's repo context)

## Test plan
- [x] Verify images still render on the GitHub repo README
- [ ] Verify images render in the HACS integration page after update

🤖 Generated with [Claude Code](https://claude.com/claude-code)