### PR TITLE
fix: editor config options not clickable

### DIFF
--- a/dist/nws-alerts-card.js
+++ b/dist/nws-alerts-card.js
@@ -410,7 +410,7 @@ const le=e=>(t,r)=>{void 0!==r?r.addInitializer(()=>{customElements.define(e,t)}
     margin-bottom: 10px;
   }
 `;let jt=class extends se{setConfig(e){this._config=e}_fireConfigChanged(e){this._config=e;const t=new CustomEvent("config-changed",{detail:{config:e},bubbles:!0,composed:!0});this.dispatchEvent(t)}_entityChanged(e){const t=e.detail.value;t!==this._config.entity&&this._fireConfigChanged({...this._config,entity:t})}_titleChanged(e){const t=e.target.value;if(t===(this._config.title||""))return;const r={...this._config};t?r.title=t:delete r.title,this._fireConfigChanged(r)}_providerChanged(e){const t=e.target.value;if(t===(this._config.provider||"auto"))return;const r={...this._config};"auto"===t?delete r.provider:r.provider=t,this._fireConfigChanged(r)}_animationsChanged(e){const t=e.target.checked;if(t===(!1!==this._config.animations))return;const r={...this._config};t?delete r.animations:r.animations=!1,this._fireConfigChanged(r)}_layoutChanged(e){const t=e.target.checked;if(t===("compact"===this._config.layout))return;const r={...this._config};t?r.layout="compact":delete r.layout,this._fireConfigChanged(r)}_zonesChanged(e){const t=e.target.value,r={...this._config};t.trim()?r.zones=t.split(",").map(e=>e.trim()).filter(Boolean):delete r.zones,this._fireConfigChanged(r)}_sortOrderChanged(e){const t=e.target.value;if(t===(this._config.sortOrder||"default"))return;const r={...this._config};"default"===t?delete r.sortOrder:r.sortOrder=t,this._fireConfigChanged(r)}_colorThemeChanged(e){const t=e.target.value;if(t===(this._config.colorTheme||"severity"))return;const r={...this._config};"severity"===t?delete r.colorTheme:r.colorTheme=t,this._fireConfigChanged(r)}render(){if(!this.hass||!this._config)return B``;const e=this._config.zones?this._config.zones.join(", "):"";return B`
-      <div class="editor">
+      <div class="editor" @closed=${e=>e.stopPropagation()}>
         <ha-selector
           .hass=${this.hass}
           .selector=${{entity:{domain:"sensor"}}}
@@ -430,7 +430,6 @@ const le=e=>(t,r)=>{void 0!==r?r.addInitializer(()=>{customElements.define(e,t)}
           .label=${"Alert provider"}
           .value=${this._config.provider||"auto"}
           @selected=${this._providerChanged}
-          @closed=${e=>e.stopPropagation()}
           fixedMenuPosition
           naturalMenuWidth
         >
@@ -451,7 +450,6 @@ const le=e=>(t,r)=>{void 0!==r?r.addInitializer(()=>{customElements.define(e,t)}
           .label=${"Sort order"}
           .value=${this._config.sortOrder||"default"}
           @selected=${this._sortOrderChanged}
-          @closed=${e=>e.stopPropagation()}
           fixedMenuPosition
           naturalMenuWidth
         >
@@ -464,7 +462,6 @@ const le=e=>(t,r)=>{void 0!==r?r.addInitializer(()=>{customElements.define(e,t)}
           .label=${"Color theme"}
           .value=${this._config.colorTheme||"severity"}
           @selected=${this._colorThemeChanged}
-          @closed=${e=>e.stopPropagation()}
           fixedMenuPosition
           naturalMenuWidth
         >

--- a/src/nws-alerts-card-editor.ts
+++ b/src/nws-alerts-card-editor.ts
@@ -119,7 +119,7 @@ export class NwsAlertsCardEditor extends LitElement {
     const zonesStr = this._config.zones ? this._config.zones.join(', ') : '';
 
     return html`
-      <div class="editor">
+      <div class="editor" @closed=${(ev: Event) => ev.stopPropagation()}>
         <ha-selector
           .hass=${this.hass}
           .selector=${{ entity: { domain: 'sensor' } }}
@@ -139,7 +139,6 @@ export class NwsAlertsCardEditor extends LitElement {
           .label=${'Alert provider'}
           .value=${this._config.provider || 'auto'}
           @selected=${this._providerChanged}
-          @closed=${(ev: Event) => ev.stopPropagation()}
           fixedMenuPosition
           naturalMenuWidth
         >
@@ -160,7 +159,6 @@ export class NwsAlertsCardEditor extends LitElement {
           .label=${'Sort order'}
           .value=${this._config.sortOrder || 'default'}
           @selected=${this._sortOrderChanged}
-          @closed=${(ev: Event) => ev.stopPropagation()}
           fixedMenuPosition
           naturalMenuWidth
         >
@@ -173,7 +171,6 @@ export class NwsAlertsCardEditor extends LitElement {
           .label=${'Color theme'}
           .value=${this._config.colorTheme || 'severity'}
           @selected=${this._colorThemeChanged}
-          @closed=${(ev: Event) => ev.stopPropagation()}
           fixedMenuPosition
           naturalMenuWidth
         >


### PR DESCRIPTION
## Summary
- Move `@closed` event `stopPropagation()` from individual `ha-select` elements to the editor root container `<div>`, catching `closed` events from **all** child components (`ha-selector`, `ha-select`, `ha-textfield`) before they propagate up and close the HA editor dialog.

Closes #14

## Test plan
- [x] Open the card's visual editor in HA
- [x] Verify entity picker, provider dropdown, sort order, color theme, zones field, and switches are all clickable and functional
- [x] Verify dropdown selections work without closing the editor dialog

🤖 Generated with [Claude Code](https://claude.com/claude-code)