### PR TITLE
fix: remove extra blank lines between changelog entries

### DIFF
--- a/cliff.toml
+++ b/cliff.toml
@@ -4,11 +4,11 @@ header = """
 """
 
 body = """
-{% for group, commits in commits | group_by(attribute="group") %}
+{%- for group, commits in commits | group_by(attribute="group") %}
 ### {{ group }}
-{% for commit in commits %}
+{% for commit in commits -%}
 - {{ commit.message | upper_first }} ({{ commit.id | truncate(length=7) }})
-{% endfor %}
+{% endfor -%}
 {% endfor %}
 """
 


### PR DESCRIPTION
## Summary
- Fix Tera template whitespace in `cliff.toml` so list items render compactly (matching v1.10.0 style) instead of having extra blank lines between them

## Test plan
- [x] Verified `npx git-cliff` output has no extra blank lines
- [x] Updated v2.0.0-alpha.1 release notes on GitHub

🤖 Generated with [Claude Code](https://claude.com/claude-code)