### PR TITLE
fix: scope release notes to correct version range

### DIFF
--- a/scripts/publish.sh
+++ b/scripts/publish.sh
@@ -4,21 +4,32 @@ set -euo pipefail
 VERSION=$1
 TAG="v$VERSION"
 
+PRERELEASE=false
+
+if [[ "$VERSION" == *"-alpha"* || "$VERSION" == *"-beta"* || "$VERSION" == *"-rc"* ]]; then
+  PRERELEASE=true
+fi
+
 git checkout main
 git pull origin main
 
 git tag "$TAG"
 git push origin "$TAG"
 
-NOTES=$(npx git-cliff \
-  --config cliff.toml \
-  --tag "$TAG" \
-  --strip header)
-
-PRERELEASE=false
-
-if [[ "$VERSION" == *"-alpha"* || "$VERSION" == *"-beta"* || "$VERSION" == *"-rc"* ]]; then
-  PRERELEASE=true
+# Prerelease: notes for just this tag's commits
+# GA release: collapse all commits since last stable tag into one section
+if [ "$PRERELEASE" = true ]; then
+  NOTES=$(npx git-cliff \
+    --config cliff.toml \
+    --latest \
+    --strip header)
+else
+  NOTES=$(npx git-cliff \
+    --config cliff.toml \
+    --tag "$TAG" \
+    --tag-pattern "^v[0-9]+\.[0-9]+\.[0-9]+$" \
+    --unreleased \
+    --strip header)
 fi
 
 gh release create "$TAG" \

--- a/scripts/release.sh
+++ b/scripts/release.sh
@@ -131,6 +131,17 @@ echo "Current version: $CURRENT"
 echo "Next version: $VERSION"
 
 # -------------------------
+# Determine cliff flags for note generation
+# GA releases ignore prerelease tags to collapse alpha/beta/rc into one section
+# -------------------------
+
+CLIFF_FLAGS=()
+
+if [[ ! "$VERSION" =~ -(alpha|beta|rc)\. ]]; then
+  CLIFF_FLAGS+=(--tag-pattern "^v[0-9]+\.[0-9]+\.[0-9]+$")
+fi
+
+# -------------------------
 # Dry-run preview
 # -------------------------
 
@@ -142,6 +153,7 @@ if [ "$DRY_RUN" = true ]; then
   npx git-cliff \
     --config cliff.toml \
     --tag "v$VERSION" \
+    "${CLIFF_FLAGS[@]}" \
     --unreleased \
     --strip header \
     "$BASE_REF"
@@ -173,7 +185,7 @@ npm version "$VERSION" --no-git-tag-version
 # Generate changelog
 # -------------------------
 
-npx git-cliff --config cliff.toml --tag "v$VERSION" --output CHANGELOG.md
+npx git-cliff --config cliff.toml --tag "v$VERSION" "${CLIFF_FLAGS[@]}" --output CHANGELOG.md
 
 git add CHANGELOG.md package.json package-lock.json
 
@@ -196,6 +208,7 @@ git push -u origin "$BRANCH"
 NOTES=$(npx git-cliff \
   --config cliff.toml \
   --tag "v$VERSION" \
+  "${CLIFF_FLAGS[@]}" \
   --unreleased \
   --strip header)
 


### PR DESCRIPTION
## Summary
- **publish.sh**: Prereleases use `--latest` (just that tag's commits). GA releases use `--tag-pattern` to ignore prerelease tags, collapsing all alpha/beta/rc commits into one section.
- **release.sh**: Add `CLIFF_FLAGS` array computed from the version string. Applied to dry-run preview, CHANGELOG.md generation, and PR body — so GA promotions aggregate all prerelease commits instead of returning empty notes.

## Test plan
- [x] `scripts/release.sh --dry-run --alpha` → shows only commits since last tag
- [x] `scripts/release.sh --dry-run` (GA promotion) → collapses alpha.1 + alpha.2 into single `## 2.0.0` section
- [x] Build, lint, tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)