### PR TITLE
fix: add migration notice to GA release notes

### DIFF
--- a/README.md
+++ b/README.md
@@ -111,7 +111,9 @@ The [MeteoAlarm integration](https://www.home-assistant.io/integrations/meteoala
 The card was renamed from "NWS Alerts Card" to "Weather Alerts Card" in v2.0 to reflect multi-provider support. **Your existing dashboards will continue to work.** The old `custom:nws-alerts-card` element name is still supported but deprecated. To migrate:
 
 1. Update your dashboard YAML: change `type: custom:nws-alerts-card` to `type: custom:weather-alerts-card`
-2. Update your resource URL (Settings → Dashboards → Resources): change `/local/nws-alerts-card.js` to `/local/weather-alerts-card.js`
+2. Update your resource URL:
+   - **HACS users:** HACS updates the resource path automatically — no action needed.
+   - **Manual install:** In Settings → Dashboards → Resources, change `/local/nws-alerts-card.js` to `/local/weather-alerts-card.js`
 3. The old names will be removed in v3.
 
 ## Development

--- a/scripts/publish.sh
+++ b/scripts/publish.sh
@@ -32,6 +32,24 @@ else
     --strip header)
 fi
 
+MIGRATION_NOTICE="
+---
+
+## Migrating from v1.x
+
+The card was renamed from **NWS Alerts Card** to **Weather Alerts Card** to reflect multi-provider support. Your existing dashboards will continue to work — the old element name is supported but deprecated.
+
+1. Update your dashboard YAML: change \`type: custom:nws-alerts-card\` to \`type: custom:weather-alerts-card\`
+2. Update your resource URL:
+   - **HACS users:** HACS updates the resource path automatically — no action needed.
+   - **Manual install:** In Settings → Dashboards → Resources, change \`/local/nws-alerts-card.js\` to \`/local/weather-alerts-card.js\`
+3. The old names will be removed in v3.
+"
+
+if [ "$PRERELEASE" = false ]; then
+  NOTES="$NOTES$MIGRATION_NOTICE"
+fi
+
 gh release create "$TAG" \
   --title "$TAG" \
   --notes "$NOTES" \


### PR DESCRIPTION
## Summary
- Appends the v1→v2 migration guide to GitHub release notes for GA releases so HACS users see it immediately on upgrade
- Clarifies in README that HACS users don't need to manually update the resource path

## Test plan
- [x] Verify README migration section reads correctly
- [x] Dry-run `publish.sh` to confirm migration notice appends to notes for GA releases but not prereleases

🤖 Generated with [Claude Code](https://claude.com/claude-code)