### PR TITLE
chore: release v2.1.0-alpha.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,14 @@
 # Changelog
 
+## 2.1.0-alpha.2 — 2026-03-15
+
+### Documentation
+- Add theme-aware hero images for README (#39) (34246fb…)
+- Expand last compact alert in hero screenshots (#40) (4749946…)
+
+### Maintenance
+- Skip release commits from changelog (ea7d32f…)
+
 ## 2.1.0-alpha.1 — 2026-03-15
 
 ### Added
@@ -15,9 +24,6 @@
 - Scope release notes to correct version range (#33) (bb30959…)
 - Add migration notice to GA release notes and clarify HACS resource path (#35) (3687b1c…)
 
-### Maintenance
-- Release v2.0.0 (#36) (fdd0c16…)
-
 ## 2.0.0-alpha.2 — 2026-03-14
 
 ### Added
@@ -26,9 +32,6 @@
 ### Fixed
 - Use npx to run git-cliff in publish script (dcefd1e…)
 - Remove extra blank lines between changelog entries (#29) (4cdabe2…)
-
-### Maintenance
-- Release v2.0.0-alpha.2 (#31) (a97466f…)
 
 ## 2.0.0-alpha.1 — 2026-03-14
 
@@ -44,15 +47,11 @@
 ### Maintenance
 - Streamline agent skills and dev workflow (#22) (f6fbc20…)
 - Add meteoalarm configuration to dev container (#24) (2065f8e…)
-- Release v2.0.0-alpha.1 (#28) (462ba83…)
 
 ## 1.10.0 — 2026-03-12
 
 ### Added
 - Add minimum severity filter configuration (#20) (068b51b…)
-
-### Maintenance
-- Release v1.10.0 (#21) (f95e06e…)
 
 ## 1.9.2 — 2026-03-10
 
@@ -60,30 +59,15 @@
 - Stop closed event propagation at editor container level (#15) (8cb7a1e…)
 - Migrate ha-select to HA 2026.02+ WebAwesome components (#17) (16e39b0…)
 
-### Maintenance
-- Release v1.9.1 (#16) (6f780f7…)
-- Release v1.9.2 (#18) (ffc8133…)
-
 ## 1.9.0 — 2026-03-09
 
 ### Fixed
 - Use absolute URLs for README images so they display in HACS (#9) (a8007af…)
 
-### Maintenance
-- Release v1.9.0 (#10) (b9c7345…)
-
 ## 1.9.0-alpha.3 — 2026-03-06
 
 ### Added
 - Support ha_bom_australia integration with area_id zone filtering (#7) (36f3d30…)
-
-### Maintenance
-- Release v1.9.0-alpha.3 (#8) (590fd6b…)
-
-## 1.9.0-alpha.2 — 2026-03-06
-
-### Maintenance
-- Release v1.9.0-alpha.2 (#6) (d63da7f…)
 
 ## 1.9.0-alpha.1 — 2026-03-06
 
@@ -98,7 +82,6 @@
 ### Maintenance
 - CI hardening, repo hygiene, and test scaffolding (#2) (bc1a46c…)
 - Update release skill for branch-protected workflow (#3) (84d5c0f…)
-- Release v1.9.0-alpha.1 (#5) (176e0bd…)
 
 ## 1.8.0 — 2026-02-20
 
@@ -109,7 +92,6 @@
 ### Maintenance
 - Update release skill gh release create flags (9b505d6…)
 - Remove obsolete docker compose version key (067c9af…)
-- Release v1.8.0 (49b7a4b…)
 
 ## 1.7.0 — 2026-02-20
 
@@ -123,23 +105,16 @@
 
 ### Maintenance
 - Add claude configuration (37787ab…)
-- Release v1.7.0 (f2e1a91…)
 
 ## 1.6.0 — 2026-02-19
 
 ### Documentation
 - Document colorTheme, compact layout, sort order, and visual editor (3e74a9b…)
 
-### Maintenance
-- Release v1.6.0 (af441a6…)
-
 ## 1.5.0 — 2026-02-19
 
 ### Added
 - Add colorTheme config option for NWS official event colors (08ccf8c…)
-
-### Maintenance
-- Release v1.5.0 (e9ce2d6…)
 
 ## 1.4.1 — 2026-02-19
 
@@ -149,27 +124,11 @@
 ### Fixed
 - Show clean in-card message when sensor is unavailable or unknown (334de9c…)
 
-### Maintenance
-- Release v1.4.1 (6c0aeee…)
-
-## 1.4.0 — 2026-02-17
-
-### Maintenance
-- Release v1.4.0 (85e104d…)
-
-## 1.3.1 — 2026-02-17
-
-### Maintenance
-- Release v1.3.1 (61ae002…)
-
 ## 1.3.0 — 2026-02-17
 
 ### Documentation
 - Add CHANGELOG.md and document release flow (2b0b60f…)
 - Add home assistant community thread link (e4c4213…)
-
-### Maintenance
-- Release v1.3.0 (0e40447…)
 
 ## 1.2.0 — 2026-02-17
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "nws-alerts-card",
-  "version": "2.1.0-alpha.1",
+  "version": "2.1.0-alpha.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "nws-alerts-card",
-      "version": "2.1.0-alpha.1",
+      "version": "2.1.0-alpha.2",
       "license": "MIT",
       "dependencies": {
         "custom-card-helpers": "^1.9.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "weather-alerts-card",
-  "version": "2.1.0-alpha.1",
+  "version": "2.1.0-alpha.2",
   "description": "A custom Home Assistant Lovelace card for displaying weather alerts",
   "main": "dist/weather-alerts-card.js",
   "module": "dist/weather-alerts-card.js",


### PR DESCRIPTION

## 2.1.0-alpha.2 — 2026-03-15

### Documentation
- Add theme-aware hero images for README (#39) (34246fb…)
- Expand last compact alert in hero screenshots (#40) (4749946…)

### Maintenance
- Skip release commits from changelog (ea7d32f…)