### PR TITLE
feat(card): add browser timezone option for traveling users

### DIFF
--- a/src/types.ts
+++ b/src/types.ts
@@ -31,6 +31,7 @@ export interface WeatherAlertsCardConfig {
   colorTheme?: 'severity' | 'nws';
   provider?: AlertProvider;  // undefined: auto-detect from entity attributes
   deduplicate?: boolean;     // undefined/true: dedup on; false: dedup off
+  timezone?: 'server' | 'browser';  // undefined/'server': HA server tz; 'browser': client tz
   _preview?: boolean;        // transient editor-only key — triggers preview mode in card
 }
 

--- a/src/weather-alerts-card-editor.ts
+++ b/src/weather-alerts-card-editor.ts
@@ -127,6 +127,18 @@ export class WeatherAlertsCardEditor extends LitElement {
     this._fireConfigChanged(newConfig);
   }
 
+  private _timezoneChanged(ev: CustomEvent): void {
+    const value = ev.detail.value as 'server' | 'browser';
+    if (value === (this._config.timezone || 'server')) return;
+    const newConfig = { ...this._config };
+    if (value === 'server') {
+      delete newConfig.timezone;
+    } else {
+      newConfig.timezone = value;
+    }
+    this._fireConfigChanged(newConfig);
+  }
+
   private _minSeverityChanged(ev: CustomEvent): void {
     const value = ev.detail.value as AlertSeverity | '';
     if (value === (this._config.minSeverity || '')) return;
@@ -210,6 +222,15 @@ export class WeatherAlertsCardEditor extends LitElement {
         >
           <ha-dropdown-item value="severity">Severity-based</ha-dropdown-item>
           <ha-dropdown-item value="nws">NWS Official</ha-dropdown-item>
+        </ha-select>
+
+        <ha-select
+          .label=${'Timezone'}
+          .value=${this._config.timezone || 'server'}
+          @selected=${this._timezoneChanged}
+        >
+          <ha-dropdown-item value="server">Server (Home Assistant)</ha-dropdown-item>
+          <ha-dropdown-item value="browser">Browser (local device)</ha-dropdown-item>
         </ha-select>
 
         <ha-select

--- a/src/weather-alerts-card.ts
+++ b/src/weather-alerts-card.ts
@@ -176,7 +176,10 @@ export class WeatherAlertsCard extends LitElement {
     if (!this.hass) {
       return { language: navigator.language || 'en', time_format: 'language' as const, date_format: 'language' as const, timeZone: undefined };
     }
-    return { ...this.hass.locale, timeZone: this.hass.config?.time_zone };
+    const timeZone = this._config?.timezone === 'browser'
+      ? Intl.DateTimeFormat().resolvedOptions().timeZone
+      : this.hass.config?.time_zone;
+    return { ...this.hass.locale, timeZone };
   }
 
   private get _animationsEnabled(): boolean {


### PR DESCRIPTION
## Summary

- Adds a `timezone` config option (`'server'` | `'browser'`) so users can display alert times in their browser's local timezone instead of the HA server's static timezone
- Addresses feedback from the NWS Alerts integration maintainer (finity) about device tracker users who travel across timezones
- Includes a visual editor dropdown between Color theme and Minimum severity; defaults to `'server'` for backward compatibility

## Test plan

- [x] `npm run build` passes cleanly
- [x] Default config (no `timezone` key) displays times in HA server timezone — no regression
- [x] Setting `timezone: browser` in YAML switches times to browser's local timezone
- [x] Visual editor dropdown appears and toggles between Server/Browser correctly
- [x] Verify with browser in a different timezone than HA server to confirm visible difference

🤖 Generated with [Claude Code](https://claude.com/claude-code)