### PR TITLE
feat(icons): expand weather icon coverage for more event types

### DIFF
--- a/src/utils.ts
+++ b/src/utils.ts
@@ -20,20 +20,40 @@ export function sanitizeAlertHtml(text: string): string {
 }
 
 const WEATHER_ICONS: [readonly string[], string][] = [
+  // Severe — specific phrases first
   [['tornado'], 'mdi:weather-tornado'],
+  [['tsunami'], 'mdi:tsunami'],
+  [['hurricane', 'tropical', 'typhoon', 'cyclone'], 'mdi:weather-hurricane'],
   [['thunderstorm', 't-storm'], 'mdi:weather-lightning'],
-  [['flood', 'hydrologic'], 'mdi:home-flood'],
+  [['hail'], 'mdi:weather-hail'],
+  // Flooding & rain
+  [['flood', 'hydrologic', 'storm surge'], 'mdi:home-flood'],
+  [['rain', 'shower', 'precipitation'], 'mdi:weather-pouring'],
+  // Winter weather
   [['snow', 'blizzard', 'winter'], 'mdi:weather-snowy-heavy'],
+  [['sleet'], 'mdi:weather-snowy-rainy'],
   [['ice', 'freeze', 'frost'], 'mdi:snowflake'],
+  [['cold', 'chill'], 'mdi:thermometer-low'],
+  // Geologic
   [['landslide', 'avalanche'], 'mdi:landslide'],
-  [['wind'], 'mdi:weather-windy'],
+  [['volcano', 'ashfall', 'vog'], 'mdi:volcano'],
+  // Airborne hazards
+  [['dust', 'sand'], 'mdi:weather-dust'],
+  [['smoke'], 'mdi:smoke'],
+  [['air quality', 'air stagnation'], 'mdi:air-filter'],
+  // Fire & heat
   [['fire', 'red flag'], 'mdi:fire'],
   [['heat'], 'mdi:weather-sunny-alert'],
+  [['drought'], 'mdi:water-off'],
   [['fog'], 'mdi:weather-fog'],
-  [['hurricane', 'tropical'], 'mdi:weather-hurricane'],
+  // Wind — "cold"/"chill" must precede "wind" so "Wind Chill" gets thermometer
   [['sheep', 'grazier'], 'mdi:weather-windy-variant'],
-  [['surf', 'marine', 'coastal'], 'mdi:waves'],
-  [['cyclone'], 'mdi:weather-hurricane'],
+  [['gale', 'squall'], 'mdi:weather-windy'],
+  [['wind'], 'mdi:weather-windy'],
+  // Marine & coastal
+  [['small craft'], 'mdi:sail-boat'],
+  [['rip current'], 'mdi:wave'],
+  [['surf', 'marine', 'coastal', 'seas'], 'mdi:waves'],
 ];
 
 export function getWeatherIcon(event: string): string {

--- a/tests/utils.test.ts
+++ b/tests/utils.test.ts
@@ -55,6 +55,78 @@ describe('getWeatherIcon', () => {
   it('returns wave icon for marine/surf events', () => {
     expect(getWeatherIcon('Hazardous Surf Warning')).toBe('mdi:waves');
   });
+
+  it('returns tsunami icon', () => {
+    expect(getWeatherIcon('Tsunami Warning')).toBe('mdi:tsunami');
+  });
+
+  it('returns hurricane icon for typhoon', () => {
+    expect(getWeatherIcon('Typhoon Warning')).toBe('mdi:weather-hurricane');
+  });
+
+  it('returns hail icon', () => {
+    expect(getWeatherIcon('Hail Storm Warning')).toBe('mdi:weather-hail');
+  });
+
+  it('returns rain icon for rain events', () => {
+    expect(getWeatherIcon('Heavy Rain Warning')).toBe('mdi:weather-pouring');
+  });
+
+  it('returns sleet icon', () => {
+    expect(getWeatherIcon('Sleet Advisory')).toBe('mdi:weather-snowy-rainy');
+  });
+
+  it('returns thermometer icon for wind chill (not wind)', () => {
+    expect(getWeatherIcon('Wind Chill Warning')).toBe('mdi:thermometer-low');
+  });
+
+  it('returns thermometer icon for extreme cold', () => {
+    expect(getWeatherIcon('Extreme Cold Warning')).toBe('mdi:thermometer-low');
+  });
+
+  it('returns dust icon', () => {
+    expect(getWeatherIcon('Dust Storm Warning')).toBe('mdi:weather-dust');
+  });
+
+  it('returns smoke icon', () => {
+    expect(getWeatherIcon('Dense Smoke Advisory')).toBe('mdi:smoke');
+  });
+
+  it('returns volcano icon', () => {
+    expect(getWeatherIcon('Ashfall Advisory')).toBe('mdi:volcano');
+  });
+
+  it('returns air filter icon for air quality', () => {
+    expect(getWeatherIcon('Air Quality Alert')).toBe('mdi:air-filter');
+  });
+
+  it('returns sailboat icon for small craft advisory', () => {
+    expect(getWeatherIcon('Small Craft Advisory')).toBe('mdi:sail-boat');
+  });
+
+  it('returns wave icon for rip current', () => {
+    expect(getWeatherIcon('Rip Current Statement')).toBe('mdi:wave');
+  });
+
+  it('returns waves icon for hazardous seas', () => {
+    expect(getWeatherIcon('Hazardous Seas Warning')).toBe('mdi:waves');
+  });
+
+  it('returns flood icon for storm surge', () => {
+    expect(getWeatherIcon('Storm Surge Warning')).toBe('mdi:home-flood');
+  });
+
+  it('returns wind icon for gale', () => {
+    expect(getWeatherIcon('Gale Warning')).toBe('mdi:weather-windy');
+  });
+
+  it('returns drought icon', () => {
+    expect(getWeatherIcon('Drought Warning')).toBe('mdi:water-off');
+  });
+
+  it('returns hurricane icon for cyclone', () => {
+    expect(getWeatherIcon('Severe Cyclone Warning')).toBe('mdi:weather-hurricane');
+  });
 });
 
 describe('getCertaintyIcon', () => {


### PR DESCRIPTION
## Summary
- Add 16 new icon mappings for event types that previously fell through to the generic `mdi:alert-circle-outline` fallback: tsunami, typhoon, hail, rain/shower, sleet, cold/chill, storm surge, dust/sand, smoke, volcano/ashfall, air quality, gale/squall, small craft, rip current, hazardous seas, and drought
- Order cold/chill patterns before wind so "Wind Chill Warning" gets `mdi:thermometer-low` instead of `mdi:weather-windy`
- Merge cyclone/typhoon into the hurricane/tropical pattern group

## Test plan
- [x] 18 new unit tests covering all added icon mappings
- [x] Existing icon tests still pass (no regressions)
- [x] Verify icons render correctly in HA with real alerts from NWS, MeteoAlarm, and BoM

🤖 Generated with [Claude Code](https://claude.com/claude-code)