### PR TITLE
chore: release v2.3.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,13 +1,18 @@
 # Changelog
 
-## 2.3.0-alpha.1 — 2026-03-23
+## 2.3.0 — 2026-03-24
 
 ### Added
 - Show preview with placeholder alerts in card picker (#53) (ab6084e…)
 - Add browser timezone option for traveling users (#55) (8316432…)
+- Add NWS event code support and filtering (#57) (d6b2eb9…)
+- Expand weather icon coverage for more event types (#58) (8894a23…)
 
 ### Fixed
 - Use NWS color-triggering keywords in placeholder alert names (861880c…)
+- Update repo links for rename to weather_alerts_card (e2a2ad0…)
+- Use old repo name in HACS link until default store updates (6b2e975…)
+- Remove HACS button until default store reflects rename (d17bfb4…)
 
 ### Maintenance
 - Regenerate adaptive hero SVG from 2x DPR PNGs (8e97cf5…)
@@ -29,53 +34,37 @@
 
 ## 2.1.0 — 2026-03-15
 
-### Documentation
-- Add adaptive hero svg (54b91a2…)
-- Add adaptive hero svg generator script (68c867d…)
-
-## 2.1.0-alpha.2 — 2026-03-15
+### Added
+- Deduplicate alerts across zones (#37) (4332648…)
 
 ### Documentation
 - Add theme-aware hero images for README (#39) (34246fb…)
 - Expand last compact alert in hero screenshots (#40) (4749946…)
-
-### Maintenance
-- Skip release commits from changelog (ea7d32f…)
-
-## 2.1.0-alpha.1 — 2026-03-15
-
-### Added
-- Deduplicate alerts across zones (#37) (4332648…)
+- Add adaptive hero svg (54b91a2…)
+- Add adaptive hero svg generator script (68c867d…)
 
 ### Fixed
 - Put migration notice before changelog in release notes (0ed28bd…)
 
+### Maintenance
+- Skip release commits from changelog (ea7d32f…)
+
 ## 2.0.0 — 2026-03-15
-
-### Fixed
-- Add version headers to changelog and fix cliff config path (#32) (58e19e1…)
-- Scope release notes to correct version range (#33) (bb30959…)
-- Add migration notice to GA release notes and clarify HACS resource path (#35) (3687b1c…)
-
-## 2.0.0-alpha.2 — 2026-03-14
-
-### Added
-- Add styled console log with card name and version at load time (#30) (c406500…)
-
-### Fixed
-- Use npx to run git-cliff in publish script (dcefd1e…)
-- Remove extra blank lines between changelog entries (#29) (4cdabe2…)
-
-## 2.0.0-alpha.1 — 2026-03-14
 
 ### Added
 - Add MeteoAlarm (Europe) adapter (#11) (6046982…)
 - Rename to "Weather Alerts Card" for multi-provider support (#25) (d302d15…)
 - Display affected area description on alert cards (#27) (89adc5e…)
+- Add styled console log with card name and version at load time (#30) (c406500…)
 
 ### Fixed
 - Remove push trigger from validate workflow to prevent duplicate runs (#23) (48fe454…)
 - Align NwsAlert type with nws_alerts integration fields (#26) (832cbee…)
+- Use npx to run git-cliff in publish script (dcefd1e…)
+- Remove extra blank lines between changelog entries (#29) (4cdabe2…)
+- Add version headers to changelog and fix cliff config path (#32) (58e19e1…)
+- Scope release notes to correct version range (#33) (bb30959…)
+- Add migration notice to GA release notes and clarify HACS resource path (#35) (3687b1c…)
 
 ### Maintenance
 - Streamline agent skills and dev workflow (#22) (f6fbc20…)
@@ -94,23 +83,17 @@
 
 ## 1.9.0 — 2026-03-09
 
-### Fixed
-- Use absolute URLs for README images so they display in HACS (#9) (a8007af…)
-
-## 1.9.0-alpha.3 — 2026-03-06
-
-### Added
-- Support ha_bom_australia integration with area_id zone filtering (#7) (36f3d30…)
-
-## 1.9.0-alpha.1 — 2026-03-06
-
 ### Added
 - Add automated screenshot utility for README images (65ffbd3…)
 - Add multi-provider adapter pattern with BoM support (#1) (#4) (320fd0f…)
+- Support ha_bom_australia integration with area_id zone filtering (#7) (36f3d30…)
 
 ### Documentation
 - Readme img udates, repo janitorial duties (412b879…)
 - Update README for official HACS procedure (126196b…)
+
+### Fixed
+- Use absolute URLs for README images so they display in HACS (#9) (a8007af…)
 
 ### Maintenance
 - CI hardening, repo hygiene, and test scaffolding (#2) (bc1a46c…)

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "nws-alerts-card",
-  "version": "2.3.0-alpha.1",
+  "version": "2.3.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "nws-alerts-card",
-      "version": "2.3.0-alpha.1",
+      "version": "2.3.0",
       "license": "MIT",
       "dependencies": {
         "custom-card-helpers": "^1.9.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "weather-alerts-card",
-  "version": "2.3.0-alpha.1",
+  "version": "2.3.0",
   "description": "A custom Home Assistant Lovelace card for displaying weather alerts",
   "main": "dist/weather-alerts-card.js",
   "module": "dist/weather-alerts-card.js",


### PR DESCRIPTION

## 2.3.0 — 2026-03-24

### Added
- Show preview with placeholder alerts in card picker (#53) (ab6084e…)
- Add browser timezone option for traveling users (#55) (8316432…)
- Add NWS event code support and filtering (#57) (d6b2eb9…)
- Expand weather icon coverage for more event types (#58) (8894a23…)

### Fixed
- Use NWS color-triggering keywords in placeholder alert names (861880c…)
- Update repo links for rename to weather_alerts_card (e2a2ad0…)
- Use old repo name in HACS link until default store updates (6b2e975…)
- Remove HACS button until default store reflects rename (d17bfb4…)

### Maintenance
- Regenerate adaptive hero SVG from 2x DPR PNGs (8e97cf5…)
- Cleanup README, release scripts, and build step (#54) (e19a382…)