### PR TITLE
docs: add missing eventCodes and timezone config to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,6 +44,8 @@ Open HACS → Search "Weather Alerts Card" → Install → Refresh your browser
 - **`sortOrder`** — `'default'`, `'onset'`, `'severity'`
 - **`minSeverity`** — `'minor'`, `'moderate'`, `'severe'`, `'extreme'`
 - **`colorTheme`** — `'severity'` (default) or `'nws'`
+- **`eventCodes`** — NWS event codes to include, e.g. `['SVR', 'TOR']` — omit for all events
+- **`timezone`** — `'server'` (default) or `'browser'` to use the client's local timezone
 - **`deduplicate`** — Collapse matching alerts into one card (default: `true`)
 - **`animations`** — `true`, `false`, or respect `prefers-reduced-motion` (default: system)
 - **`layout`** — `'default'` or `'compact'`
@@ -74,6 +76,16 @@ entity: sensor.nws_alerts_alerts
 colorTheme: nws
 layout: compact
 sortOrder: severity
+```
+
+**NWS filtered to specific event types, browser timezone**
+```yaml
+type: custom:weather-alerts-card
+entity: sensor.nws_alerts_alerts
+eventCodes:
+  - TOR
+  - SVR
+timezone: browser
 ```
 
 **European MeteoAlarm warnings**


### PR DESCRIPTION
## Summary
- Add `eventCodes` and `timezone` options to the Configuration list — these were introduced in #57 and #55 but not documented in the README
- Add a YAML example showing NWS event code filtering with browser timezone

## Test plan
- [x] Verify README renders correctly on GitHub

🤖 Generated with [Claude Code](https://claude.com/claude-code)