### PR TITLE
feat(i18n): internationalize card UI and editor for en/fr/es

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## Unreleased
+
+### Added
+- Internationalize card UI and editor: English, French, and Spanish (#46)
+
 ## 2.3.0 — 2026-03-24
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -15,6 +15,7 @@ A custom Home Assistant Lovelace card for displaying weather alerts with severit
 - **Zone filtering** — show only alerts for specific zones
 - **Sort order** — default, onset time, or severity
 - **Severity threshold** — minimum severity to display
+- **Localized UI** — English, French, and Spanish; auto-detected from Home Assistant locale
 - **Visual config** — no YAML editing required
 
 ## Quick Start

--- a/src/localize.ts
+++ b/src/localize.ts
@@ -1,0 +1,245 @@
+type TranslationMap = Record<string, string>;
+
+const en: TranslationMap = {
+  // Card UI
+  'card.no_alerts': 'No active alerts.',
+  'card.sensor_unavailable': 'Alert sensor is {state}.',
+  'card.preview': 'Preview',
+  'card.read_details': 'Read Details',
+  'card.open_source': 'Open {provider} Source',
+  'card.active': 'Active',
+  'card.in_prep': 'In Prep',
+  'card.zones_count': '{count} zones',
+  'card.zone_count_singular': '{count} zone',
+
+  // Detail labels
+  'detail.issued': 'Issued',
+  'detail.onset': 'Onset',
+  'detail.expires': 'Expires',
+  'detail.area': 'Area',
+  'detail.description': 'Description',
+  'detail.instructions': 'Instructions',
+
+  // Progress bar
+  'progress.start': 'Start',
+  'progress.now': 'Now',
+  'progress.end': 'End',
+  'progress.ongoing': 'Ongoing',
+  'progress.expires_in': 'expires {time}',
+  'progress.starts_in': 'starts {time}',
+  'progress.tbd': 'TBD',
+  'progress.na': 'N/A',
+
+  // Relative time
+  'time.just_now': 'just now',
+  'time.in_less_than_1m': 'in <1m',
+  'time.minutes_ago': '{m}m ago',
+  'time.in_minutes': 'in {m}m',
+  'time.hours_ago': '{dur} ago',
+  'time.in_hours': 'in {dur}',
+  'time.days_ago': '{d}d ago',
+  'time.in_days': 'in {d}d',
+
+  // Editor
+  'editor.entity': 'Entity (required)',
+  'editor.title': 'Title (optional)',
+  'editor.provider': 'Alert provider',
+  'editor.provider_auto': 'Auto-detect',
+  'editor.provider_nws': 'NWS (United States)',
+  'editor.provider_bom': 'BoM (Australia)',
+  'editor.provider_meteoalarm': 'MeteoAlarm (Europe)',
+  'editor.provider_pirateweather': 'PirateWeather',
+  'editor.zones': 'Zones (optional)',
+  'editor.zones_helper': 'Comma-separated zone codes, e.g. COC059, COZ039 (NWS) or NSW_FL049 (BoM)',
+  'editor.event_codes': 'Event codes (optional)',
+  'editor.event_codes_helper': 'Comma-separated NWS event codes, e.g. TOW, SVW, FFW',
+  'editor.sort_order': 'Sort order',
+  'editor.sort_default': 'Default',
+  'editor.sort_onset': 'Onset time',
+  'editor.sort_severity': 'Severity',
+  'editor.color_theme': 'Color theme',
+  'editor.color_severity': 'Severity-based',
+  'editor.color_nws': 'NWS Official',
+  'editor.timezone': 'Timezone',
+  'editor.tz_server': 'Server (Home Assistant)',
+  'editor.tz_browser': 'Browser (local device)',
+  'editor.min_severity': 'Minimum severity',
+  'editor.severity_all': 'All severities',
+  'editor.severity_minor': 'Minor or higher',
+  'editor.severity_moderate': 'Moderate or higher',
+  'editor.severity_severe': 'Severe or higher',
+  'editor.severity_extreme': 'Extreme only',
+  'editor.animations': 'Enable animations',
+  'editor.deduplicate': 'Deduplicate alerts',
+  'editor.compact': 'Compact layout',
+  'editor.show_preview': 'Show sample data',
+  'editor.preview_hint': 'Preview card layout with placeholder alerts',
+};
+
+const fr: TranslationMap = {
+  // Card UI
+  'card.no_alerts': 'Aucune alerte active.',
+  'card.sensor_unavailable': 'Le capteur d\'alerte est {state}.',
+  'card.preview': 'Apercu',
+  'card.read_details': 'Lire les details',
+  'card.open_source': 'Ouvrir la source {provider}',
+  'card.active': 'Actif',
+  'card.in_prep': 'En prep.',
+  'card.zones_count': '{count} zones',
+  'card.zone_count_singular': '{count} zone',
+
+  // Detail labels
+  'detail.issued': 'Emis',
+  'detail.onset': 'Debut',
+  'detail.expires': 'Expire',
+  'detail.area': 'Zone',
+  'detail.description': 'Description',
+  'detail.instructions': 'Instructions',
+
+  // Progress bar
+  'progress.start': 'Debut',
+  'progress.now': 'Maint.',
+  'progress.end': 'Fin',
+  'progress.ongoing': 'En cours',
+  'progress.expires_in': 'expire {time}',
+  'progress.starts_in': 'commence {time}',
+  'progress.tbd': 'Ind.',
+  'progress.na': 'N/D',
+
+  // Relative time
+  'time.just_now': 'a l\'instant',
+  'time.in_less_than_1m': 'dans <1m',
+  'time.minutes_ago': 'il y a {m}m',
+  'time.in_minutes': 'dans {m}m',
+  'time.hours_ago': 'il y a {dur}',
+  'time.in_hours': 'dans {dur}',
+  'time.days_ago': 'il y a {d}j',
+  'time.in_days': 'dans {d}j',
+
+  // Editor
+  'editor.entity': 'Entite (requis)',
+  'editor.title': 'Titre (optionnel)',
+  'editor.provider': 'Fournisseur d\'alertes',
+  'editor.provider_auto': 'Detection auto',
+  'editor.provider_nws': 'NWS (Etats-Unis)',
+  'editor.provider_bom': 'BoM (Australie)',
+  'editor.provider_meteoalarm': 'MeteoAlarm (Europe)',
+  'editor.provider_pirateweather': 'PirateWeather',
+  'editor.zones': 'Zones (optionnel)',
+  'editor.zones_helper': 'Codes de zone separes par des virgules, ex. COC059, COZ039 (NWS) ou NSW_FL049 (BoM)',
+  'editor.event_codes': 'Codes d\'evenement (optionnel)',
+  'editor.event_codes_helper': 'Codes d\'evenement NWS separes par des virgules, ex. TOW, SVW, FFW',
+  'editor.sort_order': 'Ordre de tri',
+  'editor.sort_default': 'Par defaut',
+  'editor.sort_onset': 'Heure de debut',
+  'editor.sort_severity': 'Gravite',
+  'editor.color_theme': 'Theme de couleur',
+  'editor.color_severity': 'Base sur la gravite',
+  'editor.color_nws': 'NWS officiel',
+  'editor.timezone': 'Fuseau horaire',
+  'editor.tz_server': 'Serveur (Home Assistant)',
+  'editor.tz_browser': 'Navigateur (appareil local)',
+  'editor.min_severity': 'Gravite minimale',
+  'editor.severity_all': 'Toutes les gravites',
+  'editor.severity_minor': 'Mineure ou plus',
+  'editor.severity_moderate': 'Moderee ou plus',
+  'editor.severity_severe': 'Grave ou plus',
+  'editor.severity_extreme': 'Extreme uniquement',
+  'editor.animations': 'Activer les animations',
+  'editor.deduplicate': 'Dedupliquer les alertes',
+  'editor.compact': 'Disposition compacte',
+  'editor.show_preview': 'Afficher les donnees exemples',
+  'editor.preview_hint': 'Apercu de la disposition avec des alertes fictives',
+};
+
+const es: TranslationMap = {
+  // Card UI
+  'card.no_alerts': 'Sin alertas activas.',
+  'card.sensor_unavailable': 'El sensor de alertas esta {state}.',
+  'card.preview': 'Vista previa',
+  'card.read_details': 'Leer detalles',
+  'card.open_source': 'Abrir fuente {provider}',
+  'card.active': 'Activo',
+  'card.in_prep': 'En prep.',
+  'card.zones_count': '{count} zonas',
+  'card.zone_count_singular': '{count} zona',
+
+  // Detail labels
+  'detail.issued': 'Emitido',
+  'detail.onset': 'Inicio',
+  'detail.expires': 'Expira',
+  'detail.area': 'Area',
+  'detail.description': 'Descripcion',
+  'detail.instructions': 'Instrucciones',
+
+  // Progress bar
+  'progress.start': 'Inicio',
+  'progress.now': 'Ahora',
+  'progress.end': 'Fin',
+  'progress.ongoing': 'En curso',
+  'progress.expires_in': 'expira {time}',
+  'progress.starts_in': 'comienza {time}',
+  'progress.tbd': 'Pend.',
+  'progress.na': 'N/D',
+
+  // Relative time
+  'time.just_now': 'ahora mismo',
+  'time.in_less_than_1m': 'en <1m',
+  'time.minutes_ago': 'hace {m}m',
+  'time.in_minutes': 'en {m}m',
+  'time.hours_ago': 'hace {dur}',
+  'time.in_hours': 'en {dur}',
+  'time.days_ago': 'hace {d}d',
+  'time.in_days': 'en {d}d',
+
+  // Editor
+  'editor.entity': 'Entidad (requerido)',
+  'editor.title': 'Titulo (opcional)',
+  'editor.provider': 'Proveedor de alertas',
+  'editor.provider_auto': 'Deteccion auto',
+  'editor.provider_nws': 'NWS (Estados Unidos)',
+  'editor.provider_bom': 'BoM (Australia)',
+  'editor.provider_meteoalarm': 'MeteoAlarm (Europa)',
+  'editor.provider_pirateweather': 'PirateWeather',
+  'editor.zones': 'Zonas (opcional)',
+  'editor.zones_helper': 'Codigos de zona separados por comas, ej. COC059, COZ039 (NWS) o NSW_FL049 (BoM)',
+  'editor.event_codes': 'Codigos de evento (opcional)',
+  'editor.event_codes_helper': 'Codigos de evento NWS separados por comas, ej. TOW, SVW, FFW',
+  'editor.sort_order': 'Orden',
+  'editor.sort_default': 'Predeterminado',
+  'editor.sort_onset': 'Hora de inicio',
+  'editor.sort_severity': 'Gravedad',
+  'editor.color_theme': 'Tema de color',
+  'editor.color_severity': 'Basado en gravedad',
+  'editor.color_nws': 'NWS oficial',
+  'editor.timezone': 'Zona horaria',
+  'editor.tz_server': 'Servidor (Home Assistant)',
+  'editor.tz_browser': 'Navegador (dispositivo local)',
+  'editor.min_severity': 'Gravedad minima',
+  'editor.severity_all': 'Todas las gravedades',
+  'editor.severity_minor': 'Menor o superior',
+  'editor.severity_moderate': 'Moderada o superior',
+  'editor.severity_severe': 'Grave o superior',
+  'editor.severity_extreme': 'Solo extrema',
+  'editor.animations': 'Activar animaciones',
+  'editor.deduplicate': 'Deduplicar alertas',
+  'editor.compact': 'Disposicion compacta',
+  'editor.show_preview': 'Mostrar datos de ejemplo',
+  'editor.preview_hint': 'Vista previa con alertas de ejemplo',
+};
+
+const translations: Record<string, TranslationMap> = { en, fr, es };
+
+export function t(key: string, lang: string, params?: Record<string, string | number>): string {
+  const baseLang = lang.split('-')[0].toLowerCase();
+  const map = translations[baseLang] || translations.en;
+  let value = map[key] ?? translations.en[key] ?? key;
+
+  if (params) {
+    for (const [k, v] of Object.entries(params)) {
+      value = value.replace(`{${k}}`, String(v));
+    }
+  }
+
+  return value;
+}

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -1,5 +1,6 @@
 import DOMPurify from 'dompurify';
 import { WeatherAlert, AlertProgress } from './types';
+import { t } from './localize';
 
 const ALERT_HTML_TAGS = ['a', 'b', 'br', 'em', 'i', 'li', 'ol', 'p', 'strong', 'ul'];
 
@@ -260,8 +261,8 @@ function formatTime(d: Date, locale: HaLocale | undefined, hour: '2-digit' | 'nu
   return d.toLocaleTimeString(fmt.locale, opts);
 }
 
-export function formatProgressTimestamp(ts: number, locale?: HaLocale): string {
-  if (ts <= 0) return 'N/A';
+export function formatProgressTimestamp(ts: number, locale?: HaLocale, lang = 'en'): string {
+  if (ts <= 0) return t('progress.na', lang);
   const d = new Date(ts * 1000);
   const now = new Date();
   const tzAbbr = getTzAbbr(d, locale);
@@ -271,8 +272,8 @@ export function formatProgressTimestamp(ts: number, locale?: HaLocale): string {
   return `${timeWithTz} (${formatDate(d, locale)})`;
 }
 
-export function formatLocalTimestamp(ts: number, locale?: HaLocale): string {
-  if (ts <= 100) return 'N/A';
+export function formatLocalTimestamp(ts: number, locale?: HaLocale, lang = 'en'): string {
+  if (ts <= 100) return t('progress.na', lang);
   const d = new Date(ts * 1000);
   const tzAbbr = getTzAbbr(d, locale);
   const time = formatTime(d, locale, 'numeric');
@@ -280,24 +281,24 @@ export function formatLocalTimestamp(ts: number, locale?: HaLocale): string {
   return `${formatDate(d, locale)}, ${timeStr}`;
 }
 
-export function formatRelativeTime(ts: number, nowTs: number = Date.now() / 1000): string {
+export function formatRelativeTime(ts: number, nowTs: number = Date.now() / 1000, lang = 'en'): string {
   const diff = ts - nowTs;
   const abs = Math.abs(diff);
   const past = diff < 0;
 
-  if (abs < 60) return past ? 'just now' : 'in <1m';
+  if (abs < 60) return past ? t('time.just_now', lang) : t('time.in_less_than_1m', lang);
   if (abs < 3600) {
     const m = Math.floor(abs / 60);
-    return past ? `${m}m ago` : `in ${m}m`;
+    return past ? t('time.minutes_ago', lang, { m }) : t('time.in_minutes', lang, { m });
   }
   if (abs < 86400) {
     const h = Math.floor(abs / 3600);
     const m = Math.floor((abs % 3600) / 60);
     const dur = m > 0 ? `${h}h ${m}m` : `${h}h`;
-    return past ? `${dur} ago` : `in ${dur}`;
+    return past ? t('time.hours_ago', lang, { dur }) : t('time.in_hours', lang, { dur });
   }
   const d = Math.floor(abs / 86400);
-  return past ? `${d}d ago` : `in ${d}d`;
+  return past ? t('time.days_ago', lang, { d }) : t('time.in_days', lang, { d });
 }
 
 export function normalizeSeverity(severity: string | undefined): string {

--- a/src/weather-alerts-card-editor.ts
+++ b/src/weather-alerts-card-editor.ts
@@ -1,12 +1,17 @@
 import { LitElement, html, css, TemplateResult } from 'lit';
 import { customElement, property, state } from 'lit/decorators.js';
 import { HomeAssistant, WeatherAlertsCardConfig, AlertSeverity } from './types';
+import { t } from './localize';
 
 @customElement('weather-alerts-card-editor')
 export class WeatherAlertsCardEditor extends LitElement {
   @property({ attribute: false }) public hass!: HomeAssistant;
   @state() private _config!: WeatherAlertsCardConfig;
   @state() private _showPreview = false;
+  private get _lang(): string {
+    return this.hass?.locale?.language || 'en';
+  }
+
   public setConfig(config: WeatherAlertsCardConfig): void {
     this._config = config;
   }
@@ -178,6 +183,7 @@ export class WeatherAlertsCardEditor extends LitElement {
   protected render(): TemplateResult {
     if (!this.hass || !this._config) return html``;
 
+    const lang = this._lang;
     const zonesStr = this._config.zones ? this._config.zones.join(', ') : '';
     const eventCodesStr = this._config.eventCodes ? this._config.eventCodes.join(', ') : '';
 
@@ -187,100 +193,100 @@ export class WeatherAlertsCardEditor extends LitElement {
           .hass=${this.hass}
           .selector=${{ entity: { domain: ['sensor', 'binary_sensor'] } }}
           .value=${this._config.entity}
-          .label=${'Entity (required)'}
+          .label=${t('editor.entity', lang)}
           .required=${true}
           @value-changed=${this._entityChanged}
         ></ha-selector>
 
         <ha-textfield
-          .label=${'Title (optional)'}
+          .label=${t('editor.title', lang)}
           .value=${this._config.title || ''}
           @change=${this._titleChanged}
         ></ha-textfield>
 
         <ha-select
-          .label=${'Alert provider'}
+          .label=${t('editor.provider', lang)}
           .value=${this._config.provider || 'auto'}
           @selected=${this._providerChanged}
         >
-          <ha-dropdown-item value="auto">Auto-detect</ha-dropdown-item>
-          <ha-dropdown-item value="nws">NWS (United States)</ha-dropdown-item>
-          <ha-dropdown-item value="bom">BoM (Australia)</ha-dropdown-item>
-          <ha-dropdown-item value="meteoalarm">MeteoAlarm (Europe)</ha-dropdown-item>
-          <ha-dropdown-item value="pirateweather">PirateWeather</ha-dropdown-item>
+          <ha-dropdown-item value="auto">${t('editor.provider_auto', lang)}</ha-dropdown-item>
+          <ha-dropdown-item value="nws">${t('editor.provider_nws', lang)}</ha-dropdown-item>
+          <ha-dropdown-item value="bom">${t('editor.provider_bom', lang)}</ha-dropdown-item>
+          <ha-dropdown-item value="meteoalarm">${t('editor.provider_meteoalarm', lang)}</ha-dropdown-item>
+          <ha-dropdown-item value="pirateweather">${t('editor.provider_pirateweather', lang)}</ha-dropdown-item>
         </ha-select>
 
         <ha-textfield
-          .label=${'Zones (optional)'}
+          .label=${t('editor.zones', lang)}
           .value=${zonesStr}
-          .helper=${'Comma-separated zone codes, e.g. COC059, COZ039 (NWS) or NSW_FL049 (BoM)'}
+          .helper=${t('editor.zones_helper', lang)}
           .helperPersistent=${true}
           @change=${this._zonesChanged}
         ></ha-textfield>
 
         <ha-textfield
-          .label=${'Event codes (optional)'}
+          .label=${t('editor.event_codes', lang)}
           .value=${eventCodesStr}
-          .helper=${'Comma-separated NWS event codes, e.g. TOW, SVW, FFW'}
+          .helper=${t('editor.event_codes_helper', lang)}
           .helperPersistent=${true}
           @change=${this._eventCodesChanged}
         ></ha-textfield>
 
         <ha-select
-          .label=${'Sort order'}
+          .label=${t('editor.sort_order', lang)}
           .value=${this._config.sortOrder || 'default'}
           @selected=${this._sortOrderChanged}
         >
-          <ha-dropdown-item value="default">Default</ha-dropdown-item>
-          <ha-dropdown-item value="onset">Onset time</ha-dropdown-item>
-          <ha-dropdown-item value="severity">Severity</ha-dropdown-item>
+          <ha-dropdown-item value="default">${t('editor.sort_default', lang)}</ha-dropdown-item>
+          <ha-dropdown-item value="onset">${t('editor.sort_onset', lang)}</ha-dropdown-item>
+          <ha-dropdown-item value="severity">${t('editor.sort_severity', lang)}</ha-dropdown-item>
         </ha-select>
 
         <ha-select
-          .label=${'Color theme'}
+          .label=${t('editor.color_theme', lang)}
           .value=${this._config.colorTheme || 'severity'}
           @selected=${this._colorThemeChanged}
         >
-          <ha-dropdown-item value="severity">Severity-based</ha-dropdown-item>
-          <ha-dropdown-item value="nws">NWS Official</ha-dropdown-item>
+          <ha-dropdown-item value="severity">${t('editor.color_severity', lang)}</ha-dropdown-item>
+          <ha-dropdown-item value="nws">${t('editor.color_nws', lang)}</ha-dropdown-item>
         </ha-select>
 
         <ha-select
-          .label=${'Timezone'}
+          .label=${t('editor.timezone', lang)}
           .value=${this._config.timezone || 'server'}
           @selected=${this._timezoneChanged}
         >
-          <ha-dropdown-item value="server">Server (Home Assistant)</ha-dropdown-item>
-          <ha-dropdown-item value="browser">Browser (local device)</ha-dropdown-item>
+          <ha-dropdown-item value="server">${t('editor.tz_server', lang)}</ha-dropdown-item>
+          <ha-dropdown-item value="browser">${t('editor.tz_browser', lang)}</ha-dropdown-item>
         </ha-select>
 
         <ha-select
-          .label=${'Minimum severity'}
+          .label=${t('editor.min_severity', lang)}
           .value=${this._config.minSeverity || ''}
           @selected=${this._minSeverityChanged}
         >
-          <ha-dropdown-item value="">All severities</ha-dropdown-item>
-          <ha-dropdown-item value="minor">Minor or higher</ha-dropdown-item>
-          <ha-dropdown-item value="moderate">Moderate or higher</ha-dropdown-item>
-          <ha-dropdown-item value="severe">Severe or higher</ha-dropdown-item>
-          <ha-dropdown-item value="extreme">Extreme only</ha-dropdown-item>
+          <ha-dropdown-item value="">${t('editor.severity_all', lang)}</ha-dropdown-item>
+          <ha-dropdown-item value="minor">${t('editor.severity_minor', lang)}</ha-dropdown-item>
+          <ha-dropdown-item value="moderate">${t('editor.severity_moderate', lang)}</ha-dropdown-item>
+          <ha-dropdown-item value="severe">${t('editor.severity_severe', lang)}</ha-dropdown-item>
+          <ha-dropdown-item value="extreme">${t('editor.severity_extreme', lang)}</ha-dropdown-item>
         </ha-select>
 
-        <ha-formfield .label=${'Enable animations'}>
+        <ha-formfield .label=${t('editor.animations', lang)}>
           <ha-switch
             .checked=${this._config.animations !== false}
             @change=${this._animationsChanged}
           ></ha-switch>
         </ha-formfield>
 
-        <ha-formfield .label=${'Deduplicate alerts'}>
+        <ha-formfield .label=${t('editor.deduplicate', lang)}>
           <ha-switch
             .checked=${this._config.deduplicate !== false}
             @change=${this._deduplicateChanged}
           ></ha-switch>
         </ha-formfield>
 
-        <ha-formfield .label=${'Compact layout'}>
+        <ha-formfield .label=${t('editor.compact', lang)}>
           <ha-switch
             .checked=${this._config.layout === 'compact'}
             @change=${this._layoutChanged}
@@ -288,13 +294,13 @@ export class WeatherAlertsCardEditor extends LitElement {
         </ha-formfield>
 
         <div class="preview-tools">
-          <ha-formfield .label=${'Show sample data'}>
+          <ha-formfield .label=${t('editor.show_preview', lang)}>
             <ha-switch
               .checked=${this._showPreview}
               @change=${this._previewChanged}
             ></ha-switch>
           </ha-formfield>
-          <div class="preview-hint">Preview card layout with placeholder alerts</div>
+          <div class="preview-hint">${t('editor.preview_hint', lang)}</div>
         </div>
       </div>
     `;

--- a/src/weather-alerts-card.ts
+++ b/src/weather-alerts-card.ts
@@ -16,6 +16,7 @@ import {
   sanitizeAlertHtml,
 } from './utils';
 import { getAdapter } from './adapters';
+import { t } from './localize';
 import { cardStyles } from './styles';
 import './weather-alerts-card-editor';
 
@@ -189,6 +190,10 @@ export class WeatherAlertsCard extends LitElement {
     return { ...this.hass.locale, timeZone };
   }
 
+  private get _lang(): string {
+    return this.hass?.locale?.language || 'en';
+  }
+
   private get _animationsEnabled(): boolean {
     if (this._config?.animations === true) return true;
     if (this._config?.animations === false) return false;
@@ -214,7 +219,7 @@ export class WeatherAlertsCard extends LitElement {
 
   private _sourceLinkLabel(alert: WeatherAlert): string {
     const label = PROVIDER_LABELS[alert.provider] || 'Alert';
-    return `Open ${label} Source`;
+    return t('card.open_source', this._lang, { provider: label });
   }
 
   protected render(): TemplateResult {
@@ -237,7 +242,7 @@ export class WeatherAlertsCard extends LitElement {
         <ha-card .header=${this._config.title || ''}>
           <div class="sensor-unavailable">
             <ha-icon icon="mdi:alert-circle-outline"></ha-icon>
-            Alert sensor is ${stateVal}.
+            ${t('card.sensor_unavailable', this._lang, { state: stateVal })}
           </div>
         </ha-card>
       `;
@@ -262,7 +267,7 @@ export class WeatherAlertsCard extends LitElement {
 
     return html`
       <ha-card .header=${this._config.title || ''} class="no-animations ${layoutClass}">
-        <div class="preview-label">Preview</div>
+        <div class="preview-label">${t('card.preview', this._lang)}</div>
         ${alerts.map(alert => this._renderAlert(alert))}
       </ha-card>
     `;
@@ -272,7 +277,7 @@ export class WeatherAlertsCard extends LitElement {
     return html`
       <div class="no-alerts">
         <ha-icon icon="mdi:weather-sunny"></ha-icon><br>
-        No active alerts.
+        ${t('card.no_alerts', this._lang)}
       </div>
     `;
   }
@@ -334,7 +339,7 @@ export class WeatherAlertsCard extends LitElement {
             class="details-summary"
             @click=${() => this._toggleDetails(alert.id + '_details')}
           >
-            <span>Read Details</span>
+            <span>${t('card.read_details', this._lang)}</span>
             <ha-icon
               icon="mdi:chevron-down"
               class="chevron ${this._expandedAlerts.get(alert.id + '_details') ? 'expanded' : ''}"
@@ -381,7 +386,7 @@ export class WeatherAlertsCard extends LitElement {
             class="details-summary"
             @click=${() => this._toggleDetails(alert.id)}
           >
-            <span>Read Details</span>
+            <span>${t('card.read_details', this._lang)}</span>
             <ha-icon
               icon="mdi:chevron-down"
               class="chevron ${expanded ? 'expanded' : ''}"
@@ -409,13 +414,16 @@ export class WeatherAlertsCard extends LitElement {
         <span class="badge phase-badge">${alert.phase}</span>
       ` : nothing}
       ${progress.isActive
-        ? html`<span class="badge active-badge">Active</span>`
-        : html`<span class="badge prep-badge">In Prep</span>`}
+        ? html`<span class="badge active-badge">${t('card.active', this._lang)}</span>`
+        : html`<span class="badge prep-badge">${t('card.in_prep', this._lang)}</span>`}
       ${alert.eventCode ? html`
         <span class="badge event-code-badge">${alert.eventCode}</span>
       ` : nothing}
       ${alert.mergedCount && alert.mergedCount > 1
-        ? html`<span class="badge zones-badge">${alert.mergedCount} zones</span>`
+        ? html`<span class="badge zones-badge">${t(
+            alert.mergedCount === 1 ? 'card.zone_count_singular' : 'card.zones_count',
+            this._lang, { count: alert.mergedCount },
+          )}</span>`
         : nothing}
     `;
   }
@@ -434,35 +442,37 @@ export class WeatherAlertsCard extends LitElement {
     const desc = this._normalizeText(alert.description);
     const instr = this._normalizeText(alert.instruction);
 
+    const lang = this._lang;
+
     return html`
       <div class="details-content">
         <div class="meta-grid">
           <div class="meta-item">
-            <span class="meta-label">Issued</span>
-            <span class="meta-value">${formatLocalTimestamp(progress.sentTs, this._locale)}</span>
+            <span class="meta-label">${t('detail.issued', lang)}</span>
+            <span class="meta-value">${formatLocalTimestamp(progress.sentTs, this._locale, lang)}</span>
           </div>
           <div class="meta-item">
-            <span class="meta-label">Onset</span>
-            <span class="meta-value">${formatLocalTimestamp(progress.onsetTs, this._locale)}</span>
-            <span class="meta-relative">${formatRelativeTime(progress.onsetTs, progress.nowTs)}</span>
+            <span class="meta-label">${t('detail.onset', lang)}</span>
+            <span class="meta-value">${formatLocalTimestamp(progress.onsetTs, this._locale, lang)}</span>
+            <span class="meta-relative">${formatRelativeTime(progress.onsetTs, progress.nowTs, lang)}</span>
           </div>
           <div class="meta-item">
-            <span class="meta-label">Expires</span>
-            <span class="meta-value">${formatLocalTimestamp(progress.endsTs, this._locale)}</span>
+            <span class="meta-label">${t('detail.expires', lang)}</span>
+            <span class="meta-value">${formatLocalTimestamp(progress.endsTs, this._locale, lang)}</span>
             ${progress.hasEndTime
-        ? html`<span class="meta-relative">${formatRelativeTime(progress.endsTs, progress.nowTs)}</span>`
+        ? html`<span class="meta-relative">${formatRelativeTime(progress.endsTs, progress.nowTs, lang)}</span>`
         : nothing}
           </div>
           ${alert.areaDesc ? html`
             <div class="meta-item" style="grid-column: 1 / -1;">
-              <span class="meta-label">Area</span>
+              <span class="meta-label">${t('detail.area', lang)}</span>
               <span class="meta-value">${alert.areaDesc}</span>
             </div>
           ` : nothing}
         </div>
 
-        ${this._renderTextBlock('Description', desc)}
-        ${this._renderTextBlock('Instructions', instr)}
+        ${this._renderTextBlock(t('detail.description', lang), desc)}
+        ${this._renderTextBlock(t('detail.instructions', lang), instr)}
 
         ${alert.url ? html`
           <div class="footer-link">
@@ -478,6 +488,7 @@ export class WeatherAlertsCard extends LitElement {
 
   private _renderProgressSection(_alert: WeatherAlert, progress: AlertProgress): TemplateResult {
     const { isActive, progressPct, hasEndTime, onsetTs, endsTs, nowTs } = progress;
+    const lang = this._lang;
 
     const noAnim = !this._animationsEnabled;
     const fillStyle = isActive && !hasEndTime
@@ -490,19 +501,19 @@ export class WeatherAlertsCard extends LitElement {
       <div class="progress-section">
         <div class="progress-labels">
           <div class="label-left">
-            <span class="label-sub">${isActive ? 'Start' : 'Now'}</span><br>
-            ${formatProgressTimestamp(isActive ? onsetTs : nowTs, this._locale)}
+            <span class="label-sub">${isActive ? t('progress.start', lang) : t('progress.now', lang)}</span><br>
+            ${formatProgressTimestamp(isActive ? onsetTs : nowTs, this._locale, lang)}
           </div>
           <div class="label-center">
             ${!hasEndTime
-        ? html`<span style="color: var(--color);"><b>Ongoing</b></span>`
+        ? html`<span style="color: var(--color);"><b>${t('progress.ongoing', lang)}</b></span>`
         : isActive
-          ? html`expires <b>${formatRelativeTime(endsTs, nowTs)}</b>`
-          : html`starts <b>${formatRelativeTime(onsetTs, nowTs)}</b>`}
+          ? html`${t('progress.expires_in', lang, { time: '' })}<b>${formatRelativeTime(endsTs, nowTs, lang)}</b>`
+          : html`${t('progress.starts_in', lang, { time: '' })}<b>${formatRelativeTime(onsetTs, nowTs, lang)}</b>`}
           </div>
           <div class="label-right">
-            <span class="label-sub">End</span><br>
-            ${hasEndTime ? formatProgressTimestamp(endsTs, this._locale) : 'TBD'}
+            <span class="label-sub">${t('progress.end', lang)}</span><br>
+            ${hasEndTime ? formatProgressTimestamp(endsTs, this._locale, lang) : t('progress.tbd', lang)}
           </div>
         </div>
         <div class="progress-track">

--- a/tests/localize.test.ts
+++ b/tests/localize.test.ts
@@ -1,0 +1,114 @@
+import { describe, it, expect } from 'vitest';
+import { t } from '../src/localize';
+
+describe('t()', () => {
+  it('returns English string for known key', () => {
+    expect(t('card.no_alerts', 'en')).toBe('No active alerts.');
+  });
+
+  it('returns French string for known key', () => {
+    expect(t('card.no_alerts', 'fr')).toBe('Aucune alerte active.');
+  });
+
+  it('returns Spanish string for known key', () => {
+    expect(t('card.no_alerts', 'es')).toBe('Sin alertas activas.');
+  });
+
+  it('falls back to English for unknown language', () => {
+    expect(t('card.no_alerts', 'de')).toBe('No active alerts.');
+  });
+
+  it('strips region subtag (fr-CA -> fr)', () => {
+    expect(t('card.no_alerts', 'fr-CA')).toBe('Aucune alerte active.');
+  });
+
+  it('strips region subtag (es-MX -> es)', () => {
+    expect(t('card.no_alerts', 'es-MX')).toBe('Sin alertas activas.');
+  });
+
+  it('returns the key itself for unknown key', () => {
+    expect(t('unknown.key', 'en')).toBe('unknown.key');
+  });
+
+  it('interpolates named parameters', () => {
+    expect(t('card.zones_count', 'en', { count: 3 })).toBe('3 zones');
+  });
+
+  it('interpolates named parameters in French', () => {
+    expect(t('card.sensor_unavailable', 'fr', { state: 'indisponible' }))
+      .toBe("Le capteur d'alerte est indisponible.");
+  });
+
+  it('interpolates singular zone count', () => {
+    expect(t('card.zone_count_singular', 'en', { count: 1 })).toBe('1 zone');
+  });
+
+  it('handles case-insensitive language codes', () => {
+    expect(t('card.no_alerts', 'FR')).toBe('Aucune alerte active.');
+  });
+
+  it('all en keys exist in fr', () => {
+    // Access translations indirectly through t()
+    const enKeys = [
+      'card.no_alerts', 'card.sensor_unavailable', 'card.preview', 'card.read_details',
+      'card.open_source', 'card.active', 'card.in_prep', 'card.zones_count',
+      'card.zone_count_singular',
+      'detail.issued', 'detail.onset', 'detail.expires', 'detail.area',
+      'detail.description', 'detail.instructions',
+      'progress.start', 'progress.now', 'progress.end', 'progress.ongoing',
+      'progress.expires_in', 'progress.starts_in', 'progress.tbd', 'progress.na',
+      'time.just_now', 'time.in_less_than_1m', 'time.minutes_ago', 'time.in_minutes',
+      'time.hours_ago', 'time.in_hours', 'time.days_ago', 'time.in_days',
+      'editor.entity', 'editor.title', 'editor.provider', 'editor.provider_auto',
+      'editor.provider_nws', 'editor.provider_bom', 'editor.provider_meteoalarm',
+      'editor.provider_pirateweather', 'editor.zones', 'editor.zones_helper',
+      'editor.event_codes', 'editor.event_codes_helper', 'editor.sort_order',
+      'editor.sort_default', 'editor.sort_onset', 'editor.sort_severity',
+      'editor.color_theme', 'editor.color_severity', 'editor.color_nws',
+      'editor.timezone', 'editor.tz_server', 'editor.tz_browser',
+      'editor.min_severity', 'editor.severity_all', 'editor.severity_minor',
+      'editor.severity_moderate', 'editor.severity_severe', 'editor.severity_extreme',
+      'editor.animations', 'editor.deduplicate', 'editor.compact',
+      'editor.show_preview', 'editor.preview_hint',
+    ];
+
+    for (const key of enKeys) {
+      const frValue = t(key, 'fr');
+      const enValue = t(key, 'en');
+      // fr should not fall back to en (i.e., they should differ or be intentionally the same)
+      expect(frValue).not.toBe(key, `Missing fr translation for: ${key}`);
+      // Sanity: en value exists
+      expect(enValue).not.toBe(key, `Missing en translation for: ${key}`);
+    }
+  });
+
+  it('all en keys exist in es', () => {
+    const enKeys = [
+      'card.no_alerts', 'card.sensor_unavailable', 'card.preview', 'card.read_details',
+      'card.open_source', 'card.active', 'card.in_prep', 'card.zones_count',
+      'card.zone_count_singular',
+      'detail.issued', 'detail.onset', 'detail.expires', 'detail.area',
+      'detail.description', 'detail.instructions',
+      'progress.start', 'progress.now', 'progress.end', 'progress.ongoing',
+      'progress.expires_in', 'progress.starts_in', 'progress.tbd', 'progress.na',
+      'time.just_now', 'time.in_less_than_1m', 'time.minutes_ago', 'time.in_minutes',
+      'time.hours_ago', 'time.in_hours', 'time.days_ago', 'time.in_days',
+      'editor.entity', 'editor.title', 'editor.provider', 'editor.provider_auto',
+      'editor.provider_nws', 'editor.provider_bom', 'editor.provider_meteoalarm',
+      'editor.provider_pirateweather', 'editor.zones', 'editor.zones_helper',
+      'editor.event_codes', 'editor.event_codes_helper', 'editor.sort_order',
+      'editor.sort_default', 'editor.sort_onset', 'editor.sort_severity',
+      'editor.color_theme', 'editor.color_severity', 'editor.color_nws',
+      'editor.timezone', 'editor.tz_server', 'editor.tz_browser',
+      'editor.min_severity', 'editor.severity_all', 'editor.severity_minor',
+      'editor.severity_moderate', 'editor.severity_severe', 'editor.severity_extreme',
+      'editor.animations', 'editor.deduplicate', 'editor.compact',
+      'editor.show_preview', 'editor.preview_hint',
+    ];
+
+    for (const key of enKeys) {
+      const esValue = t(key, 'es');
+      expect(esValue).not.toBe(key, `Missing es translation for: ${key}`);
+    }
+  });
+});

--- a/tests/utils.test.ts
+++ b/tests/utils.test.ts
@@ -321,6 +321,22 @@ describe('formatRelativeTime', () => {
   it('returns days for long durations', () => {
     expect(formatRelativeTime(now + 172800, now)).toBe('in 2d');
   });
+
+  it('returns French relative time', () => {
+    expect(formatRelativeTime(now - 30, now, 'fr')).toBe("a l'instant");
+    expect(formatRelativeTime(now + 300, now, 'fr')).toBe('dans 5m');
+    expect(formatRelativeTime(now - 300, now, 'fr')).toBe('il y a 5m');
+    expect(formatRelativeTime(now + 5400, now, 'fr')).toBe('dans 1h 30m');
+    expect(formatRelativeTime(now + 172800, now, 'fr')).toBe('dans 2j');
+  });
+
+  it('returns Spanish relative time', () => {
+    expect(formatRelativeTime(now - 30, now, 'es')).toBe('ahora mismo');
+    expect(formatRelativeTime(now + 300, now, 'es')).toBe('en 5m');
+    expect(formatRelativeTime(now - 300, now, 'es')).toBe('hace 5m');
+    expect(formatRelativeTime(now + 5400, now, 'es')).toBe('en 1h 30m');
+    expect(formatRelativeTime(now + 172800, now, 'es')).toBe('en 2d');
+  });
 });
 
 describe('deduplicateAlerts', () => {


### PR DESCRIPTION
## Summary
- Add `src/localize.ts` with translation maps (en, fr, es) and `t(key, lang, params?)` lookup function with region subtag stripping and English fallback
- Replace all hardcoded UI strings in card (`weather-alerts-card.ts`) and editor (`weather-alerts-card-editor.ts`) with `t()` calls, auto-detected from `hass.locale.language`
- Add optional `lang` parameter to `formatRelativeTime()`, `formatProgressTimestamp()`, and `formatLocalTimestamp()` in `utils.ts`
- Add unit tests for localization module (13 tests) and French/Spanish relative time formatting

Closes #46

## Test plan
- [x] All 174 existing + new tests pass (`npm test`)
- [x] Build passes (`npm run build`)
- [x] Lint passes (`npm run lint`)
- [x] Manual: set HA locale to `fr` and verify card + editor render in French
- [x] Manual: set HA locale to `es` and verify card + editor render in Spanish
- [x] Manual: verify `fr-CA` locale falls back to French translations
- [x] Manual: verify unsupported locale (e.g. `de`) falls back to English

🤖 Generated with [Claude Code](https://claude.com/claude-code)