### PR TITLE
fix(ci): HACS validation for fork PRs

### DIFF
--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -12,6 +12,13 @@ jobs:
   validate-hacs:
     runs-on: ubuntu-latest
     steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 20
+          cache: 'npm'
+      - run: npm ci
+      - run: npm run build
       - name: HACS validation
         uses: hacs/action@main
         with:


### PR DESCRIPTION
## Summary
- Add checkout and build steps before `hacs/action` in the validate workflow
- Without checkout, the HACS action falls back to GitHub API validation, which resolves fork PRs to the fork repo — where `dist/` is gitignored and the built JS file doesn't exist
- With checkout + build, HACS validates the local workspace with the built artifact, working for both fork and same-repo PRs

## Test plan
- [x] Verify HACS validation passes on this PR
- [ ] Verify HACS validation passes on PR #67 (external fork PR) after merge

🤖 Generated with [Claude Code](https://claude.com/claude-code)