### PR TITLE
fix(ci): run HACS validation on main push only, not PRs

### DIFF
--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -1,7 +1,8 @@
 name: Validate
 
 on:
-  pull_request:
+  push:
+    branches: [main]
   schedule:
     - cron: "0 0 * * *"
   workflow_dispatch:
@@ -12,13 +13,6 @@ jobs:
   validate-hacs:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-node@v4
-        with:
-          node-version: 20
-          cache: 'npm'
-      - run: npm ci
-      - run: npm run build
       - name: HACS validation
         uses: hacs/action@main
         with:


### PR DESCRIPTION
## Summary
- Replace `pull_request` trigger with `push: branches: [main]` for HACS validation
- Removes the checkout+build steps added in #68 — they're unnecessary when the check only runs on main (where releases exist)
- Fork PRs no longer fail HACS validation since it doesn't run on PRs at all
- The `build` workflow already validates compilation on every PR

## Test plan
- [x] Verify HACS validation does **not** trigger on this PR
- [x] Verify HACS validation runs after merge to main
- [x] Verify PR #67 no longer shows a failing HACS check

🤖 Generated with [Claude Code](https://claude.com/claude-code)