### PR TITLE
chore: release v2.5.0-alpha.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,9 +1,10 @@
 # Changelog
 
-## Unreleased
+## 2.5.0-alpha.2 — 2026-03-26
 
 ### Added
-- Add `showSourceLink` config option to hide source links for kiosk deployments (#75)
+- Display alert headlines with smart redundancy filtering (#76) (2718014…)
+- Add showSourceLink config option to hide source links (#75) (#77) (7ccad91…)
 
 ## 2.5.0-alpha.1 — 2026-03-26
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "nws-alerts-card",
-  "version": "2.5.0-alpha.1",
+  "version": "2.5.0-alpha.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "nws-alerts-card",
-      "version": "2.5.0-alpha.1",
+      "version": "2.5.0-alpha.2",
       "license": "MIT",
       "dependencies": {
         "custom-card-helpers": "^1.9.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "weather-alerts-card",
-  "version": "2.5.0-alpha.1",
+  "version": "2.5.0-alpha.2",
   "description": "A custom Home Assistant Lovelace card for displaying weather alerts",
   "main": "dist/weather-alerts-card.js",
   "module": "dist/weather-alerts-card.js",


### PR DESCRIPTION

## 2.5.0-alpha.2 — 2026-03-26

### Added
- Display alert headlines with smart redundancy filtering (#76) (2718014…)
- Add showSourceLink config option to hide source links (#75) (#77) (7ccad91…)