### PR TITLE
fix: prevent HACS validate race with release asset upload

### DIFF
--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -3,6 +3,10 @@ name: Validate
 on:
   push:
     branches: [main]
+    paths: [hacs.json]
+  workflow_run:
+    workflows: [Release]
+    types: [completed]
   schedule:
     - cron: "0 0 * * *"
   workflow_dispatch:


### PR DESCRIPTION
## Summary
- Narrow the `push` trigger to only fire when `hacs.json` changes (the only repo-structure file HACS cares about)
- Add `workflow_run` trigger so Validate runs after the Release workflow completes, avoiding the race where HACS checks for release assets before they're uploaded

The v2.5.0 release triggered both workflows simultaneously — Validate ran 16s before the Release workflow finished uploading assets, causing a "structure not compliant" failure.

## Test plan
- [ ] Verify Validate no longer triggers on normal pushes to main (only hacs.json changes)
- [ ] Verify Validate runs after Release workflow completes
- [ ] Verify scheduled and manual dispatch triggers still work

🤖 Generated with [Claude Code](https://claude.com/claude-code)