### PR TITLE
fix: restore validate push trigger on all main commits

### DIFF
--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -3,7 +3,6 @@ name: Validate
 on:
   push:
     branches: [main]
-    paths: [hacs.json]
   workflow_run:
     workflows: [Release]
     types: [completed]


### PR DESCRIPTION
## Summary
- Remove the `paths: [hacs.json]` filter added in #83 so validation runs on every push to main again
- The `workflow_run` trigger after Release (also from #83) stays, ensuring a clean run once assets are uploaded

## Test plan
- [x] Verify Validate triggers on any push to main
- [x] Verify Validate still triggers after Release workflow completes

🤖 Generated with [Claude Code](https://claude.com/claude-code)