### PR TITLE
chore: release v2.5.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## 2.5.1 — 2026-03-27
+
+### Fixed
+- Prevent HACS validate race with release asset upload (#83) (20c377e…)
+- Restore push trigger on all main commits (#84) (58e94f0…)
+
 ## 2.5.0 — 2026-03-26
 
 ### Added

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "nws-alerts-card",
-  "version": "2.5.0",
+  "version": "2.5.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "nws-alerts-card",
-      "version": "2.5.0",
+      "version": "2.5.1",
       "license": "MIT",
       "dependencies": {
         "custom-card-helpers": "^1.9.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "weather-alerts-card",
-  "version": "2.5.0",
+  "version": "2.5.1",
   "description": "A custom Home Assistant Lovelace card for displaying weather alerts",
   "main": "dist/weather-alerts-card.js",
   "module": "dist/weather-alerts-card.js",


### PR DESCRIPTION

## 2.5.1 — 2026-03-27

### Fixed
- Prevent HACS validate race with release asset upload (#83) (20c377e…)
- Restore push trigger on all main commits (#84) (58e94f0…)