### PR TITLE
fix: default showProvider to false

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -75,7 +75,7 @@ interface WeatherAlertsCardConfig {
   hideNoAlerts?: boolean;      // undefined/false: show "No active alerts" banner; true: hide it
   showDetails?: boolean;       // undefined/true: show expandable detail panel; false: hide entirely
   expandDetails?: boolean;     // undefined/false: details collapsed behind toggle; true: details always visible, toggle removed
-  showProvider?: boolean;      // undefined/true: show provider label above title; false: hide
+  showProvider?: boolean;      // undefined/false: hide provider label; true: show above title
   showMetadata?: boolean;      // undefined/true: show metadata grid in details; false: hide
   showDescription?: boolean;   // undefined/true: show description block in details; false: hide
   showInstructions?: boolean;  // undefined/true: show instructions block in details; false: hide

--- a/README.md
+++ b/README.md
@@ -63,7 +63,7 @@ Then click the Download button, and click Reload when prompted.
 | `animations` | system | `true`, `false`, or respect `prefers-reduced-motion` |
 | `showDetails` | `true` | Show the expandable detail panel (hides entire "Read Details" section when `false`) |
 | `expandDetails` | `false` | Always show details inline without a toggle (ideal for wall-mounted displays) |
-| `showProvider` | `true` | Show provider label (e.g., NWS) above event title |
+| `showProvider` | `false` | Show provider label (e.g., NWS) above event title |
 | `showMetadata` | `true` | Show issued/onset/expires/area grid in detail panel |
 | `showDescription` | `true` | Show description text in detail panel |
 | `showInstructions` | `true` | Show instructions text in detail panel |

--- a/src/types.ts
+++ b/src/types.ts
@@ -45,7 +45,7 @@ export interface WeatherAlertsCardConfig {
   showMetadata?: boolean;    // undefined/true: show metadata grid in details; false: hide
   showDescription?: boolean; // undefined/true: show description block in details; false: hide
   showInstructions?: boolean; // undefined/true: show instructions block in details; false: hide
-  showProvider?: boolean;    // undefined/true: show provider hint above title when multiple providers configured; false: hide
+  showProvider?: boolean;    // undefined/false: hide provider hint; true: show provider label above title
   showSourceLink?: boolean;  // undefined/true: show "Open Source" link; false: hide link (kiosk mode)
   timezone?: 'server' | 'browser';  // undefined/'server': HA server tz; 'browser': client tz
   reformatText?: boolean;    // undefined/true: strip hard line wraps from alert text; false: preserve raw formatting

--- a/src/weather-alerts-card-editor.ts
+++ b/src/weather-alerts-card-editor.ts
@@ -259,12 +259,12 @@ export class WeatherAlertsCardEditor extends LitElement {
   private _showProviderChanged(ev: Event): void {
     const target = ev.target as HTMLInputElement;
     const show = target.checked;
-    if (show === (this._config.showProvider !== false)) return;
+    if (show === (this._config.showProvider === true)) return;
     const newConfig = { ...this._config };
     if (show) {
-      delete newConfig.showProvider;
+      newConfig.showProvider = true;
     } else {
-      newConfig.showProvider = false;
+      delete newConfig.showProvider;
     }
     this._fireConfigChanged(newConfig);
   }
@@ -539,7 +539,7 @@ export class WeatherAlertsCardEditor extends LitElement {
 
         <ha-formfield .label=${t('editor.show_provider', lang)}>
           <ha-switch
-            .checked=${this._config.showProvider !== false}
+            .checked=${this._config.showProvider === true}
             @change=${this._showProviderChanged}
           ></ha-switch>
         </ha-formfield>

--- a/src/weather-alerts-card.ts
+++ b/src/weather-alerts-card.ts
@@ -562,7 +562,7 @@ export class WeatherAlertsCard extends LitElement {
   }
 
   private _renderProviderHint(alert: WeatherAlert): TemplateResult | typeof nothing {
-    if (this._config?.showProvider === false) return nothing;
+    if (this._config?.showProvider !== true) return nothing;
     const code = PROVIDER_SHORT[alert.provider] || alert.provider.toUpperCase();
     return html`<span class="provider-hint">${code}</span>`;
   }


### PR DESCRIPTION
## Summary
- Flips `showProvider` default from `true` to `false` so existing configs without the key no longer unexpectedly show provider labels
- Existing explicit `showProvider: true` or `showProvider: false` values are unaffected
- Updates editor toggle, renderer check, type comments, AGENTS.md, and README docs

## Test plan
- [x] Verify card with no `showProvider` key hides the provider label
- [x] Verify `showProvider: true` shows the provider label
- [x] Verify `showProvider: false` still hides the provider label
- [x] Verify editor toggle starts unchecked and correctly sets/removes the key

🤖 Generated with [Claude Code](https://claude.com/claude-code)