### PR TITLE
docs: add Support section to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -250,6 +250,10 @@ The card was renamed from "NWS Alerts Card" to "Weather Alerts Card" in v2.0 to 
 
 </details>
 
+## Support
+
+If you find this card useful, tip me at [Ko-fi](https://ko-fi.com/seeveezee) to support development, or donate to [The Y'all Squad](https://www.theyallsquad.org/donate) — a rapid-response program providing direct aid, chainsaws, and supplies to families affected by severe weather events.
+
 ---
 
 **Resources:** [Home Assistant Community thread](https://community.home-assistant.io/t/nws-alerts-card)


### PR DESCRIPTION
## Summary
- Adds a Support section above the Resources footer with two links: Ko-fi (development) and The Y'all Squad (disaster relief)
- Matches the README's terse, utility-first tone — plain inline links rather than badges or a table

## Test plan
- [x] Verify rendered Markdown on GitHub looks correct
- [x] Confirm both links resolve

🤖 Generated with [Claude Code](https://claude.com/claude-code)