### PR TITLE
fix(editor): use OR wrapper for multi-entity hideNoAlerts visibility

### DIFF
--- a/src/weather-alerts-card-editor.ts
+++ b/src/weather-alerts-card-editor.ts
@@ -315,34 +315,49 @@ export class WeatherAlertsCardEditor extends LitElement {
     this._fireConfigChanged(newConfig);
   }
 
-  /**
-   * Add or remove our managed visibility condition.
-   * Preserves any user-defined conditions already present.
-   */
-  private _syncVisibilityCondition(
-    existing: Record<string, unknown>[] | undefined,
-    entity: string,
-    add: boolean,
-  ): Record<string, unknown>[] | undefined {
-    const isOurs = (c: Record<string, unknown>): boolean =>
-      c.condition === 'state' && c.entity === entity
-      && ('state_not' in c || 'state' in c);
-    const conditions = (existing || []).filter(c => !isOurs(c));
-    if (add) {
-      // binary_sensor (MeteoAlarm) uses "on"/"off"; sensors use numeric count "0","1",...
-      if (entity.startsWith('binary_sensor.')) {
-        conditions.push({ condition: 'state', entity, state: 'on' });
-      } else {
-        conditions.push({ condition: 'state', entity, state_not: '0' });
-      }
+  private _buildEntityCondition(entity: string): Record<string, unknown> {
+    // binary_sensor (MeteoAlarm) uses "on"/"off"; sensors use numeric count "0","1",...
+    if (entity.startsWith('binary_sensor.')) {
+      return { condition: 'state', entity, state: 'on' };
     }
-    return conditions.length > 0 ? conditions : undefined;
+    return { condition: 'state', entity, state_not: '0' };
+  }
+
+  private _isManagedCondition(
+    c: Record<string, unknown>,
+    managedIds: Set<string>,
+  ): boolean {
+    // Flat managed condition: scoped to current entity IDs so we don't disturb
+    // unrelated user-authored state conditions.
+    if (
+      c.condition === 'state'
+      && typeof c.entity === 'string'
+      && managedIds.has(c.entity)
+      && ('state_not' in c || 'state' in c)
+    ) {
+      return true;
+    }
+    // OR wrapper: matched by shape so stale wrappers (e.g. after entity
+    // removal) are also cleaned up on the next sync.
+    if (c.condition === 'or' && Array.isArray(c.conditions)) {
+      const subs = c.conditions as Record<string, unknown>[];
+      return subs.length > 0 && subs.every(sub =>
+        sub.condition === 'state'
+        && typeof sub.entity === 'string'
+        && (
+          ('state_not' in sub && sub.state_not === '0')
+          || ('state' in sub && sub.state === 'on')
+        ),
+      );
+    }
+    return false;
   }
 
   /**
    * Rebuild visibility conditions for all configured entities (primary + extras).
-   * When hideNoAlerts is true, adds a condition per entity (OR logic in HA).
-   * When false, removes all managed conditions.
+   * HA combines top-level visibility conditions with AND, so for 2+ entities we
+   * wrap per-entity state conditions in an `or` block — otherwise the card
+   * would stay hidden unless every entity had alerts.
    */
   private _syncMultiEntityVisibility(
     config: WeatherAlertsCardConfig,
@@ -351,20 +366,20 @@ export class WeatherAlertsCardEditor extends LitElement {
     if (config.entity) allIds.add(config.entity);
     if (config.entities) config.entities.forEach(id => allIds.add(id));
 
-    // Strip all our managed conditions first
-    let conditions = config.visibility;
-    for (const id of allIds) {
-      conditions = this._syncVisibilityCondition(conditions, id, false);
-    }
+    const conditions = (config.visibility || []).filter(
+      c => !this._isManagedCondition(c, allIds),
+    );
 
-    // Re-add if hideNoAlerts is active
-    if (config.hideNoAlerts) {
-      for (const id of allIds) {
-        conditions = this._syncVisibilityCondition(conditions, id, true);
+    if (config.hideNoAlerts && allIds.size > 0) {
+      const perEntity = [...allIds].map(id => this._buildEntityCondition(id));
+      if (perEntity.length === 1) {
+        conditions.push(perEntity[0]);
+      } else {
+        conditions.push({ condition: 'or', conditions: perEntity });
       }
     }
 
-    return conditions;
+    return conditions.length > 0 ? conditions : undefined;
   }
 
   private _reformatTextChanged(ev: Event): void {

--- a/src/weather-alerts-card-editor.ts
+++ b/src/weather-alerts-card-editor.ts
@@ -120,7 +120,12 @@ export class WeatherAlertsCardEditor extends LitElement {
     }
 
     if (newConfig.hideNoAlerts) {
-      newConfig.visibility = this._syncMultiEntityVisibility(newConfig);
+      const visibility = this._syncMultiEntityVisibility(newConfig);
+      if (visibility) {
+        newConfig.visibility = visibility;
+      } else {
+        delete newConfig.visibility;
+      }
     }
     this._fireConfigChanged(newConfig);
   }
@@ -307,10 +312,11 @@ export class WeatherAlertsCardEditor extends LitElement {
     }
     // Sync HA's native visibility conditions so the dashboard layout
     // fully removes the card (no residual gap) when there are no alerts.
-    if (hide) {
-      newConfig.visibility = this._syncMultiEntityVisibility(newConfig);
+    const visibility = this._syncMultiEntityVisibility(newConfig);
+    if (visibility) {
+      newConfig.visibility = visibility;
     } else {
-      newConfig.visibility = this._syncMultiEntityVisibility(newConfig);
+      delete newConfig.visibility;
     }
     this._fireConfigChanged(newConfig);
   }

--- a/tests/editor-visibility.test.ts
+++ b/tests/editor-visibility.test.ts
@@ -1,0 +1,199 @@
+import { describe, it, expect } from 'vitest';
+import { WeatherAlertsCardEditor } from '../src/weather-alerts-card-editor';
+import type { WeatherAlertsCardConfig } from '../src/types';
+
+// Reach into private helpers — this suite exists to pin down the
+// condition-matching heuristics used to sync HA visibility conditions.
+type EditorInternals = {
+  _syncMultiEntityVisibility(
+    config: WeatherAlertsCardConfig,
+  ): Record<string, unknown>[] | undefined;
+  _isManagedCondition(
+    c: Record<string, unknown>,
+    managedIds: Set<string>,
+  ): boolean;
+};
+
+function makeEditor(): EditorInternals {
+  return new WeatherAlertsCardEditor() as unknown as EditorInternals;
+}
+
+function makeConfig(overrides: Partial<WeatherAlertsCardConfig>): WeatherAlertsCardConfig {
+  return {
+    entity: 'sensor.nws_alerts',
+    ...overrides,
+  };
+}
+
+describe('_syncMultiEntityVisibility', () => {
+  it('returns undefined when hideNoAlerts is off and no other conditions exist', () => {
+    const editor = makeEditor();
+    expect(editor._syncMultiEntityVisibility(makeConfig({}))).toBeUndefined();
+  });
+
+  it('emits a flat state_not condition for a single sensor entity', () => {
+    const editor = makeEditor();
+    const result = editor._syncMultiEntityVisibility(makeConfig({ hideNoAlerts: true }));
+    expect(result).toEqual([
+      { condition: 'state', entity: 'sensor.nws_alerts', state_not: '0' },
+    ]);
+  });
+
+  it('emits state: on for a single binary_sensor entity', () => {
+    const editor = makeEditor();
+    const result = editor._syncMultiEntityVisibility(makeConfig({
+      entity: 'binary_sensor.meteoalarm',
+      hideNoAlerts: true,
+    }));
+    expect(result).toEqual([
+      { condition: 'state', entity: 'binary_sensor.meteoalarm', state: 'on' },
+    ]);
+  });
+
+  it('wraps multi-entity conditions in an OR block', () => {
+    const editor = makeEditor();
+    const result = editor._syncMultiEntityVisibility(makeConfig({
+      entity: 'sensor.nws_alerts',
+      entities: ['sensor.nws_alerts_2', 'binary_sensor.meteoalarm'],
+      hideNoAlerts: true,
+    }));
+    expect(result).toHaveLength(1);
+    expect(result![0]).toEqual({
+      condition: 'or',
+      conditions: [
+        { condition: 'state', entity: 'sensor.nws_alerts', state_not: '0' },
+        { condition: 'state', entity: 'sensor.nws_alerts_2', state_not: '0' },
+        { condition: 'state', entity: 'binary_sensor.meteoalarm', state: 'on' },
+      ],
+    });
+  });
+
+  it('preserves unrelated user-authored conditions', () => {
+    const editor = makeEditor();
+    const userCondition = {
+      condition: 'state',
+      entity: 'input_boolean.dashboard_mode',
+      state: 'on',
+    };
+    const result = editor._syncMultiEntityVisibility(makeConfig({
+      hideNoAlerts: true,
+      visibility: [userCondition],
+    }));
+    expect(result).toEqual([
+      userCondition,
+      { condition: 'state', entity: 'sensor.nws_alerts', state_not: '0' },
+    ]);
+  });
+
+  it('strips managed conditions when hideNoAlerts is turned off', () => {
+    const editor = makeEditor();
+    const userCondition = {
+      condition: 'state',
+      entity: 'input_boolean.dashboard_mode',
+      state: 'on',
+    };
+    const result = editor._syncMultiEntityVisibility(makeConfig({
+      hideNoAlerts: false,
+      visibility: [
+        userCondition,
+        { condition: 'state', entity: 'sensor.nws_alerts', state_not: '0' },
+      ],
+    }));
+    expect(result).toEqual([userCondition]);
+  });
+
+  it('replaces a flat condition with an OR wrapper when a second entity is added', () => {
+    const editor = makeEditor();
+    const result = editor._syncMultiEntityVisibility(makeConfig({
+      entity: 'sensor.nws_alerts',
+      entities: ['sensor.nws_alerts_2'],
+      hideNoAlerts: true,
+      visibility: [
+        { condition: 'state', entity: 'sensor.nws_alerts', state_not: '0' },
+      ],
+    }));
+    expect(result).toEqual([
+      {
+        condition: 'or',
+        conditions: [
+          { condition: 'state', entity: 'sensor.nws_alerts', state_not: '0' },
+          { condition: 'state', entity: 'sensor.nws_alerts_2', state_not: '0' },
+        ],
+      },
+    ]);
+  });
+
+  it('cleans up a stale OR wrapper referencing a removed entity', () => {
+    const editor = makeEditor();
+    const result = editor._syncMultiEntityVisibility(makeConfig({
+      entity: 'sensor.nws_alerts',
+      hideNoAlerts: true,
+      visibility: [
+        {
+          condition: 'or',
+          conditions: [
+            { condition: 'state', entity: 'sensor.nws_alerts', state_not: '0' },
+            { condition: 'state', entity: 'sensor.removed', state_not: '0' },
+          ],
+        },
+      ],
+    }));
+    expect(result).toEqual([
+      { condition: 'state', entity: 'sensor.nws_alerts', state_not: '0' },
+    ]);
+  });
+});
+
+describe('_isManagedCondition', () => {
+  it('recognizes a flat state_not condition for a managed entity', () => {
+    const editor = makeEditor();
+    expect(editor._isManagedCondition(
+      { condition: 'state', entity: 'sensor.x', state_not: '0' },
+      new Set(['sensor.x']),
+    )).toBe(true);
+  });
+
+  it('ignores flat state conditions for non-managed entities', () => {
+    const editor = makeEditor();
+    expect(editor._isManagedCondition(
+      { condition: 'state', entity: 'input_boolean.other', state: 'on' },
+      new Set(['sensor.x']),
+    )).toBe(false);
+  });
+
+  it('recognizes an OR wrapper whose subs all match the managed shape', () => {
+    const editor = makeEditor();
+    expect(editor._isManagedCondition(
+      {
+        condition: 'or',
+        conditions: [
+          { condition: 'state', entity: 'sensor.a', state_not: '0' },
+          { condition: 'state', entity: 'binary_sensor.b', state: 'on' },
+        ],
+      },
+      new Set(),
+    )).toBe(true);
+  });
+
+  it('leaves an OR block with non-matching subs alone', () => {
+    const editor = makeEditor();
+    expect(editor._isManagedCondition(
+      {
+        condition: 'or',
+        conditions: [
+          { condition: 'state', entity: 'sensor.a', state_not: '0' },
+          { condition: 'state', entity: 'input_boolean.mode', state: 'off' },
+        ],
+      },
+      new Set(),
+    )).toBe(false);
+  });
+
+  it('does not treat an empty OR block as managed', () => {
+    const editor = makeEditor();
+    expect(editor._isManagedCondition(
+      { condition: 'or', conditions: [] },
+      new Set(),
+    )).toBe(false);
+  });
+});


### PR DESCRIPTION
## Summary
- Wrap per-entity visibility conditions in an `or` block when 2+ entities are configured so the card shows when **any** entity has alerts (HA ANDs top-level conditions by default, which caused the card to hide unless every entity had alerts).
- Single-entity configs still emit a flat condition (backward compatible).
- OR wrapper is shape-matched on strip so stale wrappers from removed entities get cleaned up on the next sync.
- Collapse duplicated `if`/`else` in `_hideNoAlertsChanged` and align `_entityChanged` so both toggle paths `delete newConfig.visibility` when the synced result is empty instead of leaving an `undefined` property.
- Add `tests/editor-visibility.test.ts` (13 cases) covering single vs multi-entity shapes, flat↔OR transitions on entity add/remove, stale OR cleanup, preservation of user-authored conditions, and the `_isManagedCondition` shape heuristics.

## Why
With the previous logic, if the primary `entity` had no alerts but an `entities` extra did, the dashboard hid the card (AND over per-entity `state_not: '0'` failed on the primary), while edit mode still rendered the alert because internal rendering merges alerts across all entities. This fixes that divergence.

## Test plan
- [x] Configure card with primary entity (no alerts) + additional entity (active alert), enable "Hide card when there are no active alerts" — card should remain visible on the dashboard.
- [x] All entities have 0 alerts — card hides.
- [x] Single-entity config still emits a flat `state_not: '0'` condition.
- [x] Remove an entity from `entities` after having toggled hideNoAlerts — stale OR wrapper gets rebuilt with only current entities.
- [x] `npm run lint` passes.
- [x] `npm test` passes (297 tests).

🤖 Generated with [Claude Code](https://claude.com/claude-code)