### PR TITLE
chore(docker): use host networking with explicit DNS

### DIFF
--- a/.docker/docker-compose.yml
+++ b/.docker/docker-compose.yml
@@ -5,7 +5,10 @@ services:
       dockerfile: .docker/Dockerfile
     container_name: weather-alerts-card-ha
     restart: unless-stopped
-    network_mode: bridge
+    network_mode: host
+    dns:
+      - 1.1.1.1
+      - 8.8.8.8
     ports:
       - "8123:8123"
     volumes:


### PR DESCRIPTION
## Summary
- Dev container's default bridge network was unreliable for outbound DNS resolution to NWS / MeteoAlarm APIs from inside HA.
- Switches \`.docker/docker-compose.yml\` to \`network_mode: host\` and pins \`dns: [1.1.1.1, 8.8.8.8]\` so external fetches work without docker-desktop-specific tweaks.

## Test plan
- [x] \`docker compose -f .docker/docker-compose.yml up\` starts HA at http://localhost:8123
- [x] NWS Alerts integration successfully pulls alerts from inside the container
- [x] Verify on at least one non-Linux host (macOS / Windows) that host networking doesn't regress the flow

## Notes
The existing \`ports: 8123:8123\` mapping is a no-op under host networking (the container shares the host's network stack). Left in place for self-documentation; has no effect.

🤖 Generated with [Claude Code](https://claude.com/claude-code)