### PR TITLE
chore(testing-zones): split MeteoAlarm areaDesc on commas

### DIFF
--- a/scripts/testing-zones.sh
+++ b/scripts/testing-zones.sh
@@ -585,17 +585,28 @@ meteoalarm() {
   # Province-level analysis from the top country's cached feed
   local atom_file="$CACHE_DIR/meteoalarm-atom-${top_slug}.xml"
 
-  if [ -s "$atom_file" ]; then
+  # Split areaDesc on commas — some countries (e.g. Ukraine) aggregate all
+  # affected regions into a single areaDesc. HA's meteoalarm integration
+  # matches province as a substring of areaDesc, so individual region names
+  # surface far more diverse alerts than the full aggregated string.
+  local areas
+  areas=$(grep -oP '(?<=<cap:areaDesc>)[^<]+' "$atom_file" 2>/dev/null \
+    | sed 's/&amp;amp;/\&/g; s/&amp;/\&/g' \
+    | tr ',' '\n' \
+    | sed 's/^[[:space:]]*//; s/[[:space:]]*$//' \
+    | grep -v '^$')
+
+  if [ -n "$areas" ]; then
     echo ""
     echo "  ── Top provinces ──"
-    grep -oP '(?<=<cap:areaDesc>)[^<]+' "$atom_file" | sed 's/&amp;amp;/\&/g; s/&amp;/\&/g' | sort | uniq -c | sort -rn | head -5 | \
+    echo "$areas" | sort | uniq -c | sort -rn | head -5 | \
       while read -r cnt name; do
-        printf "    %-35s %s alerts\n" "$name" "$cnt"
+        printf "    %-50s %s alerts\n" "$name" "$cnt"
       done
   fi
 
   local top_province
-  top_province=$(grep -oP '(?<=<cap:areaDesc>)[^<]+' "$atom_file" 2>/dev/null | sed 's/&amp;amp;/\&/g; s/&amp;/\&/g' | sort | uniq -c | sort -rn | head -1 | sed 's/^ *[0-9]* *//')
+  top_province=$(echo "$areas" | sort | uniq -c | sort -rn | head -1 | sed 's/^ *[0-9]* *//')
 
   echo ""
   echo "  country:  $top_slug"


### PR DESCRIPTION
## Summary
- Some countries (e.g. Ukraine) aggregate every affected region into a single \`<cap:areaDesc>\` value in their MeteoAlarm feed. The previous province analysis in \`scripts/testing-zones.sh\` bucketed those as one giant string, hiding real diversity.
- Splits \`areaDesc\` on commas before counting, so the top-5 province list surfaces individual region names — which is what HA's meteoalarm integration actually matches against.
- Widens the province column from 35 to 50 chars to fit the longer individual names that now appear.

## Test plan
- [x] \`scripts/testing-zones.sh meteoalarm\` produces a readable top-5 province table for Ukraine
- [x] Output for other countries (Germany, Italy) remains reasonable — no regression in the single-\`areaDesc\`-per-row case
- [x] \`shellcheck scripts/testing-zones.sh\` clean (or no new warnings)

🤖 Generated with [Claude Code](https://claude.com/claude-code)