### PR TITLE
feat: pass through provider-supplied MDI icon from CAP adapter

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## Unreleased
+
+### Added
+- CAP adapter: pass through provider-supplied MDI icon (`attributes.icon`) as `providerIcon` on `WeatherAlert`; both compact and full layouts prefer it over the dictionary lookup
+
 ## 3.0.0-alpha.3 — 2026-05-12
 
 ### Added

--- a/src/adapters/cap.ts
+++ b/src/adapters/cap.ts
@@ -34,6 +34,9 @@ export class CapAdapter implements AlertAdapter {
     const onsetTs = parseTimestamp(str(attributes['onset'])) || sentTs;
     const endsTs = parseTimestamp(str(attributes['ends'])) || parseTimestamp(str(attributes['expires']));
 
+    const rawIcon = str(attributes['icon']);
+    const providerIcon = rawIcon.startsWith('mdi:') ? rawIcon : undefined;
+
     return [{
       id,
       event: event || 'Unknown',
@@ -55,6 +58,7 @@ export class CapAdapter implements AlertAdapter {
       phase: phaseLabel(str(attributes['phase'])),
       severityInferred: !rawSeverity && !normalizedSev,
       certaintyInferred: false,
+      ...(providerIcon !== undefined && { providerIcon }),
     }];
   }
 }

--- a/src/types.ts
+++ b/src/types.ts
@@ -108,6 +108,7 @@ export interface WeatherAlert {
   severityInferred: boolean;  // true if severity was synthesized/inferred, not raw from provider
   certaintyInferred: boolean; // true if certainty was synthesized/inferred, not raw from provider
   iconHint?: string;       // English keyword for icon lookup when event may be localized (e.g. MeteoAlarm)
+  providerIcon?: string;   // Raw MDI icon from provider (e.g. 'mdi:weather-tornado'); bypasses dictionary when present
   mergedCount?: number;    // Number of alerts collapsed by dedup (set only when > 1)
   colorHint?: string;      // Provider-published color tag (currently only ECCC: red/orange/yellow/grey/green); consumed by getEcccColor when colorTheme: 'eccc'
   severityBadgeLabel?: string; // Optional override for the severity badge text (rendered raw, e.g. ECCC's `impact` field "High"/"Élevée"). Falls back to localized tier when absent.

--- a/src/weather-alerts-card.ts
+++ b/src/weather-alerts-card.ts
@@ -717,7 +717,7 @@ export class WeatherAlertsCard extends LitElement {
           @click=${() => this._toggleDetails(alert.id)}
         >
           <div class="icon-box">
-            <ha-icon icon=${getWeatherIcon(alert.iconHint || alert.event)}></ha-icon>
+            <ha-icon icon=${alert.providerIcon ?? getWeatherIcon(alert.iconHint || alert.event)}></ha-icon>
           </div>
           ${this._renderProviderHint(alert)}
           <span class="alert-title">${alert.event}</span>
@@ -781,7 +781,7 @@ export class WeatherAlertsCard extends LitElement {
       <div class="alert-card ${className} ${phaseClass} ${boostClasses}" style=${this._alertColorStyle(alert)}>
         <div class="alert-header-row">
           <div class="icon-box">
-            <ha-icon icon=${getWeatherIcon(alert.iconHint || alert.event)}></ha-icon>
+            <ha-icon icon=${alert.providerIcon ?? getWeatherIcon(alert.iconHint || alert.event)}></ha-icon>
           </div>
           <div class="info-box">
             <div class="title-row">

--- a/tests/adapters/cap.test.ts
+++ b/tests/adapters/cap.test.ts
@@ -193,6 +193,28 @@ describe('CapAdapter', () => {
       expect(alerts[0].phase).toBe('');
     });
 
+    describe('providerIcon passthrough', () => {
+      it('passes through a valid mdi: icon from attributes', () => {
+        const alerts = adapter.parseAlerts(makeCapAttributes({ icon: 'mdi:weather-tornado' }));
+        expect(alerts[0].providerIcon).toBe('mdi:weather-tornado');
+      });
+
+      it('ignores an empty icon attribute', () => {
+        const alerts = adapter.parseAlerts(makeCapAttributes({ icon: '' }));
+        expect(alerts[0].providerIcon).toBeUndefined();
+      });
+
+      it('ignores a non-mdi: string (e.g. hass: prefix)', () => {
+        const alerts = adapter.parseAlerts(makeCapAttributes({ icon: 'hass:thermostat' }));
+        expect(alerts[0].providerIcon).toBeUndefined();
+      });
+
+      it('leaves providerIcon absent when icon attribute is missing', () => {
+        const alerts = adapter.parseAlerts(makeCapAttributes());
+        expect(Object.prototype.hasOwnProperty.call(alerts[0], 'providerIcon')).toBe(false);
+      });
+    });
+
     it('handles missing optional fields gracefully', () => {
       const alerts = adapter.parseAlerts({
         incident_platform_version: '1.0',


### PR DESCRIPTION
## Summary

- Adds `providerIcon?: string` to `WeatherAlert` — an additive, backwards-compatible field for adapters to supply a raw MDI icon string that bypasses the `getWeatherIcon()` dictionary lookup
- CAP adapter reads `attributes['icon']`, validates the `mdi:` prefix, and populates `providerIcon` via a spread-conditional (key is absent, not `undefined`, when not set)
- Both compact and full card icon render sites prefer `alert.providerIcon` over the dictionary when present (`??` operator)

## Test plan

- [x] 4 new unit tests in `tests/adapters/cap.test.ts` — valid `mdi:` passthrough, empty string ignored, non-`mdi:` prefix ignored, key absent when attribute missing
- [x] All 500 tests pass (`npm test`)
- [x] `npm run lint` clean
- [x] `npm run build` clean
- [x] Manual: CAP alert entity with `attributes.icon = 'mdi:weather-tornado'` renders the tornado icon in both compact and full layouts

🤖 Generated with [Claude Code](https://claude.com/claude-code)