### PR TITLE
feat: dismiss trigger + style options, pointer drag-to-dismiss

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -85,8 +85,10 @@ interface WeatherAlertsCardConfig {
   showInstructions?: boolean;  // undefined/true: show instructions block in details; false: hide
   showSourceLink?: boolean;    // undefined/true: show "Open Source" link; false: hide (kiosk mode)
   timezone?: 'server' | 'browser'; // undefined/'server': HA server tz; 'browser': client tz
-  allowDismiss?: boolean;      // undefined/false: no dismiss UI; true: per-alert × button backed by browser-local dismissal list (keyed on entity-set hash). Re-surfaces automatically when severity/sentTs/endsTs/phase change
+  allowDismiss?: boolean;      // undefined/false: no dismiss UI; true: per-alert dismiss gesture/button backed by browser-local dismissal list (keyed on entity-set hash). Re-surfaces automatically when severity/sentTs/endsTs/phase change
   showDismissUndo?: boolean;   // undefined/true: fire HA's hass-notification toast with Undo on dismiss; false: silent. Has no effect when allowDismiss is off
+  dismissTrigger?: 'button' | 'swipe' | 'both';  // undefined/'button': × button only; 'swipe': left drag/swipe only — Pointer Events unify touch swipe and mouse click-drag, so this stays operable for desktop users (no button is rendered); 'both': drag + button. Requires allowDismiss: true
+  dismissButtonStyle?: 'icon' | 'labeled';  // undefined/'icon': × icon only; 'labeled': neutral "Dismiss" pill positioned as window-decoration at the card's top-right (compact layout always shows icon-only). No effect when dismissTrigger: 'swipe'
 }
 ```
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 ### Added
 - CAP adapter: pass through provider-supplied MDI icon (`attributes.icon`) as `providerIcon` on `WeatherAlert`; both compact and full layouts prefer it over the dictionary lookup
+- Dismissal as a first-class feature: dedicated **Dismissal** editor section, `dismissTrigger` option (`button` / `swipe` / `both`), `dismissButtonStyle` option (`icon` / `labeled`), and a unified drag-to-dismiss gesture (touch swipe + mouse click-drag via Pointer Events) with spring-back and reduced-motion support. Labeled button uses neutral chrome colors and is positioned as window-decoration at the card's top-right so long event titles flow full-width (#151 follow-up)
 
 ## 3.0.0-alpha.3 — 2026-05-12
 

--- a/src/localize.ts
+++ b/src/localize.ts
@@ -9,7 +9,7 @@ const en: TranslationMap = {
   'card.open_source': 'Open {provider} Source',
   'card.zones_count': '{count} zones',
   'card.zone_count_singular': '{count} zone',
-  'card.dismiss': 'Dismiss alert',
+  'card.dismiss': 'Dismiss',
   'card.dismissed_toast': 'Dismissed: {event}',
   'card.dismissed_toast_undo': 'Undo',
 
@@ -139,6 +139,14 @@ const en: TranslationMap = {
   'editor.section_appearance': 'Appearance',
   'editor.section_detail_panel': 'Detail Panel',
   'editor.section_behavior': 'Behavior',
+  'editor.section_dismissal': 'Dismissal',
+  'editor.dismiss_trigger': 'Dismiss trigger',
+  'editor.dismiss_trigger_button': 'Button only',
+  'editor.dismiss_trigger_swipe': 'Swipe only',
+  'editor.dismiss_trigger_both': 'Button and swipe',
+  'editor.dismiss_button_style': 'Button style',
+  'editor.dismiss_button_style_icon': 'Icon only',
+  'editor.dismiss_button_style_labeled': 'Icon and label',
 };
 
 const fr: TranslationMap = {
@@ -150,7 +158,7 @@ const fr: TranslationMap = {
   'card.open_source': 'Ouvrir la source {provider}',
   'card.zones_count': '{count} zones',
   'card.zone_count_singular': '{count} zone',
-  'card.dismiss': 'Ignorer l\'alerte',
+  'card.dismiss': 'Ignorer',
   'card.dismissed_toast': 'Ignorée : {event}',
   'card.dismissed_toast_undo': 'Annuler',
 
@@ -280,6 +288,14 @@ const fr: TranslationMap = {
   'editor.section_appearance': 'Apparence',
   'editor.section_detail_panel': 'Panneau de details',
   'editor.section_behavior': 'Comportement',
+  'editor.section_dismissal': 'Masquage',
+  'editor.dismiss_trigger': 'Declencheur',
+  'editor.dismiss_trigger_button': 'Bouton uniquement',
+  'editor.dismiss_trigger_swipe': 'Glissement uniquement',
+  'editor.dismiss_trigger_both': 'Bouton et glissement',
+  'editor.dismiss_button_style': 'Style du bouton',
+  'editor.dismiss_button_style_icon': 'Icone uniquement',
+  'editor.dismiss_button_style_labeled': 'Icone et texte',
 };
 
 const es: TranslationMap = {
@@ -291,7 +307,7 @@ const es: TranslationMap = {
   'card.open_source': 'Abrir fuente {provider}',
   'card.zones_count': '{count} zonas',
   'card.zone_count_singular': '{count} zona',
-  'card.dismiss': 'Descartar alerta',
+  'card.dismiss': 'Descartar',
   'card.dismissed_toast': 'Descartada: {event}',
   'card.dismissed_toast_undo': 'Deshacer',
 
@@ -421,6 +437,14 @@ const es: TranslationMap = {
   'editor.section_appearance': 'Apariencia',
   'editor.section_detail_panel': 'Panel de detalles',
   'editor.section_behavior': 'Comportamiento',
+  'editor.section_dismissal': 'Descarte',
+  'editor.dismiss_trigger': 'Disparador',
+  'editor.dismiss_trigger_button': 'Solo boton',
+  'editor.dismiss_trigger_swipe': 'Solo deslizamiento',
+  'editor.dismiss_trigger_both': 'Boton y deslizamiento',
+  'editor.dismiss_button_style': 'Estilo del boton',
+  'editor.dismiss_button_style_icon': 'Solo icono',
+  'editor.dismiss_button_style_labeled': 'Icono y texto',
 };
 
 const it: TranslationMap = {
@@ -432,7 +456,7 @@ const it: TranslationMap = {
   'card.open_source': 'Apri fonte {provider}',
   'card.zones_count': '{count} zone',
   'card.zone_count_singular': '{count} zona',
-  'card.dismiss': 'Ignora allerta',
+  'card.dismiss': 'Ignora',
   'card.dismissed_toast': 'Ignorata: {event}',
   'card.dismissed_toast_undo': 'Annulla',
 
@@ -562,6 +586,14 @@ const it: TranslationMap = {
   'editor.section_appearance': 'Aspetto',
   'editor.section_detail_panel': 'Pannello dettagli',
   'editor.section_behavior': 'Comportamento',
+  'editor.section_dismissal': 'Dismissione',
+  'editor.dismiss_trigger': 'Attivatore',
+  'editor.dismiss_trigger_button': 'Solo pulsante',
+  'editor.dismiss_trigger_swipe': 'Solo scorrimento',
+  'editor.dismiss_trigger_both': 'Pulsante e scorrimento',
+  'editor.dismiss_button_style': 'Stile pulsante',
+  'editor.dismiss_button_style_icon': 'Solo icona',
+  'editor.dismiss_button_style_labeled': 'Icona e testo',
 };
 
 const de: TranslationMap = {
@@ -573,7 +605,7 @@ const de: TranslationMap = {
   'card.open_source': '{provider}-Quelle öffnen',
   'card.zones_count': '{count} Zonen',
   'card.zone_count_singular': '{count} Zone',
-  'card.dismiss': 'Warnung ausblenden',
+  'card.dismiss': 'Ausblenden',
   'card.dismissed_toast': 'Ausgeblendet: {event}',
   'card.dismissed_toast_undo': 'Rückgängig',
 
@@ -703,6 +735,14 @@ const de: TranslationMap = {
   'editor.section_appearance': 'Darstellung',
   'editor.section_detail_panel': 'Detailbereich',
   'editor.section_behavior': 'Verhalten',
+  'editor.section_dismissal': 'Ausblenden',
+  'editor.dismiss_trigger': 'Auslöser',
+  'editor.dismiss_trigger_button': 'Nur Schaltfläche',
+  'editor.dismiss_trigger_swipe': 'Nur wischen',
+  'editor.dismiss_trigger_both': 'Schaltfläche und wischen',
+  'editor.dismiss_button_style': 'Schaltflächenstil',
+  'editor.dismiss_button_style_icon': 'Nur Symbol',
+  'editor.dismiss_button_style_labeled': 'Symbol und Text',
 };
 
 const translations: Record<string, TranslationMap> = { en, fr, es, it, de };

--- a/src/styles.ts
+++ b/src/styles.ts
@@ -471,11 +471,15 @@ export const cardStyles = css`
     background: rgba(var(--rgb-primary-text-color, 128, 128, 128), 0.08);
     outline: none;
   }
-  /* Full layout: align the button to the top-right of the header row so it
-     doesn't fight the icon/info block vertically. */
+  /* Full layout: corner-tuck the dismiss button as window-decoration so it
+     doesn't reserve space in the flex flow (which would squeeze title,
+     headline, area, and badges). Labeled variant overrides position below
+     to sit flush against the card's rounded corner. */
   .alert-header-row:not(.compact-row) > .dismiss-button {
-    align-self: flex-start;
-    margin-left: auto;
+    position: absolute;
+    top: 6px;
+    right: 6px;
+    margin-left: 0;
   }
   .compact-row > .dismiss-button {
     margin-left: 4px;

--- a/src/styles.ts
+++ b/src/styles.ts
@@ -74,7 +74,7 @@ export const cardStyles = css`
     border: 1px solid var(--divider-color);
     box-shadow: var(--ha-card-box-shadow, 0 2px 5px rgba(0,0,0,0.1));
     overflow: hidden;
-    transition: border-color 0.2s ease-in-out, box-shadow 0.2s ease-in-out;
+    transition: border-color 0.2s ease-in-out, box-shadow 0.2s ease-in-out, transform 0.15s ease-out;
   }
 
   /* Contrast boost: only when theme mode matches the failing side.
@@ -479,6 +479,74 @@ export const cardStyles = css`
   }
   .compact-row > .dismiss-button {
     margin-left: 4px;
+  }
+
+  /* Labeled dismiss button (full layout only) — window-decoration placement:
+     absolute at top-right of the card, outside the header flex flow, so title,
+     headline, area, and badges flow full row width. The button is visually
+     subtle and overlays the rare long title that reaches its column. */
+  .dismiss-button.labeled {
+    border-left: 1px solid var(--divider-color);
+    border-bottom: 1px solid var(--divider-color);
+    border-radius: 12px;
+    padding: 2px 8px 2px 4px;
+    color: var(--secondary-text-color);
+    opacity: 1;
+    gap: 4px;
+    font-size: calc(0.78rem * var(--wac-scale, 1));
+    width: auto;
+    height: auto;
+    --mdc-icon-size: calc(16px * var(--wac-scale, 1));
+  }
+  .dismiss-button.labeled:hover,
+  .dismiss-button.labeled:focus-visible {
+    background: rgba(var(--rgb-primary-text-color, 128, 128, 128), 0.08);
+    opacity: 1;
+  }
+  .alert-header-row:not(.compact-row) > .dismiss-button.labeled {
+    position: absolute;
+    top: 0px;
+    right: 0px;
+    margin-left: 0;
+  }
+  /* Compact row: revert labeled button to icon-only */
+  .compact-row > .dismiss-button.labeled {
+    border: none;
+    border-radius: 50%;
+    padding: 0;
+    color: var(--secondary-text-color);
+    gap: 0;
+    font-size: inherit;
+    width: calc(24px * var(--wac-scale, 1));
+    height: calc(24px * var(--wac-scale, 1));
+    --mdc-icon-size: calc(18px * var(--wac-scale, 1));
+  }
+  .compact-row > .dismiss-button.labeled span {
+    display: none;
+  }
+
+  /* --- SWIPE GESTURE ---
+     swipe-enabled: applied whenever pointer drag-to-dismiss is wired up. Sets
+     touch-action so vertical scroll stays native while horizontal is reserved
+     for the JS gesture; shows the grab cursor on hover. */
+  .alert-card.swipe-enabled {
+    touch-action: pan-y;
+    cursor: grab;
+  }
+  .alert-card.swiping {
+    transition: none !important;
+    user-select: none;
+    cursor: grabbing;
+  }
+  .alert-card.swipe-exit {
+    transform: translateX(-110%) !important;
+    opacity: 0 !important;
+    transition: transform 0.2s ease-in, opacity 0.2s ease-in !important;
+  }
+  @media (prefers-reduced-motion: reduce) {
+    .alert-card.swipe-exit {
+      transition: none !important;
+    }
   }
 
   /* --- COMPACT LAYOUT --- */

--- a/src/types.ts
+++ b/src/types.ts
@@ -70,6 +70,8 @@ export interface WeatherAlertsCardConfig {
   reformatText?: boolean;    // undefined/true: strip hard line wraps from alert text; false: preserve raw formatting
   allowDismiss?: boolean;    // undefined/false: no dismiss UI; true: per-alert × button with browser-local dismissal list
   showDismissUndo?: boolean; // undefined/true: fire HA toast on dismiss; false: silent. No effect when allowDismiss is off
+  dismissTrigger?: 'button' | 'swipe' | 'both'; // undefined/'button': × button only; 'swipe': left drag/swipe only (touch + mouse via Pointer Events; no button); 'both': button + drag. Requires allowDismiss: true
+  dismissButtonStyle?: 'icon' | 'labeled'; // undefined/'icon': × icon only; 'labeled': icon + "Dismiss" text pill (compact always icon-only). No effect when dismissTrigger: 'swipe'
   _preview?: boolean;        // transient editor-only key — triggers preview mode in card
   visibility?: Record<string, unknown>[];  // HA-managed visibility conditions (set via dashboard editor)
 }

--- a/src/weather-alerts-card-editor.ts
+++ b/src/weather-alerts-card-editor.ts
@@ -431,6 +431,30 @@ export class WeatherAlertsCardEditor extends LitElement {
     this._fireConfigChanged(newConfig);
   }
 
+  private _dismissTriggerChanged(ev: CustomEvent): void {
+    const value = ev.detail.value as 'button' | 'swipe' | 'both';
+    if (value === (this._config.dismissTrigger || 'button')) return;
+    const newConfig = { ...this._config };
+    if (value === 'button') {
+      delete newConfig.dismissTrigger;
+    } else {
+      newConfig.dismissTrigger = value;
+    }
+    this._fireConfigChanged(newConfig);
+  }
+
+  private _dismissButtonStyleChanged(ev: CustomEvent): void {
+    const value = ev.detail.value as 'icon' | 'labeled';
+    if (value === (this._config.dismissButtonStyle || 'icon')) return;
+    const newConfig = { ...this._config };
+    if (value === 'icon') {
+      delete newConfig.dismissButtonStyle;
+    } else {
+      newConfig.dismissButtonStyle = value;
+    }
+    this._fireConfigChanged(newConfig);
+  }
+
   private _currentScopeHash(): string {
     const ids = this._getSelectedEntities();
     if (ids.length === 0) return '';
@@ -942,12 +966,38 @@ export class WeatherAlertsCardEditor extends LitElement {
           ></ha-switch>
         </ha-formfield>
 
+        <!-- Dismissal -->
+        <div class="section-label">${t('editor.section_dismissal', lang)}</div>
+
         <ha-formfield .label=${t('editor.allow_dismiss', lang)}>
           <ha-switch
             .checked=${this._config.allowDismiss === true}
             @change=${this._allowDismissChanged}
           ></ha-switch>
         </ha-formfield>
+
+        ${this._config.allowDismiss === true ? html`
+          <ha-select
+            .label=${t('editor.dismiss_trigger', lang)}
+            .value=${this._config.dismissTrigger || 'button'}
+            @selected=${this._dismissTriggerChanged}
+          >
+            <ha-dropdown-item value="button">${t('editor.dismiss_trigger_button', lang)}</ha-dropdown-item>
+            <ha-dropdown-item value="swipe">${t('editor.dismiss_trigger_swipe', lang)}</ha-dropdown-item>
+            <ha-dropdown-item value="both">${t('editor.dismiss_trigger_both', lang)}</ha-dropdown-item>
+          </ha-select>
+
+          ${this._config.dismissTrigger !== 'swipe' ? html`
+            <ha-select
+              .label=${t('editor.dismiss_button_style', lang)}
+              .value=${this._config.dismissButtonStyle || 'icon'}
+              @selected=${this._dismissButtonStyleChanged}
+            >
+              <ha-dropdown-item value="icon">${t('editor.dismiss_button_style_icon', lang)}</ha-dropdown-item>
+              <ha-dropdown-item value="labeled">${t('editor.dismiss_button_style_labeled', lang)}</ha-dropdown-item>
+            </ha-select>
+          ` : nothing}
+        ` : nothing}
 
         <ha-formfield .label=${t('editor.show_dismiss_undo', lang)}>
           <ha-switch

--- a/src/weather-alerts-card.ts
+++ b/src/weather-alerts-card.ts
@@ -170,6 +170,19 @@ export class WeatherAlertsCard extends LitElement {
   private _dismissalsScope = '';
   private _unsubscribeDismissals?: () => void;
 
+  // Pointer-drag-to-dismiss gesture state (plain fields — requestUpdate() called manually).
+  // Unifies touch swipe and mouse drag via Pointer Events; setPointerCapture takes
+  // over after lock so drags that leave the card still resolve to this element.
+  private _swipeState: { id: string; offset: number; locked: boolean; cardWidth: number } | null = null;
+  private _swipeStartX = 0;
+  private _swipeStartY = 0;
+  private _swipeCurrentDx = 0;
+  private _swipeRAF: number | null = null;
+  private _swipePointerId: number | null = null;
+  private _swipeExitTimeout: number | null = null;
+  private _swipeJustDragged = false;
+  @state() private _swipeExiting: string | null = null;
+
   // Live entity-registry copy. `null` until the WS subscription delivers;
   // resolution helpers fall back to `hass.entities` while it is null.
   private _registryEntries: EntityRegistryDisplayEntry[] | null = null;
@@ -196,6 +209,16 @@ export class WeatherAlertsCard extends LitElement {
     this._unsubscribeDismissals?.();
     this._unsubscribeDismissals = undefined;
     this._teardownRegistrySubscription();
+    if (this._swipeRAF !== null) {
+      cancelAnimationFrame(this._swipeRAF);
+      this._swipeRAF = null;
+    }
+    if (this._swipeExitTimeout !== null) {
+      clearTimeout(this._swipeExitTimeout);
+      this._swipeExitTimeout = null;
+    }
+    this._swipeState = null;
+    this._swipeExiting = null;
     if (this._config?.entity || this._config?.device) {
       WeatherAlertsCard._editorExpandedState.set(this._entityStateKey(), this._expandedAlerts);
     }
@@ -437,8 +460,146 @@ export class WeatherAlertsCard extends LitElement {
     return !!this._config?.allowDismiss && !this._forcePreview;
   }
 
+  private _swipeEnabled(): boolean {
+    return this._canDismiss()
+      && (this._config?.dismissTrigger === 'swipe' || this._config?.dismissTrigger === 'both');
+  }
+
+  private _onSwipePointerDown(alert: WeatherAlert, e: PointerEvent): void {
+    if (!this._swipeEnabled()) return;
+    if (this._swipeState) return;
+    // Primary button only — ignores right/middle click and pen barrel buttons.
+    if (e.button !== 0) return;
+    this._swipePointerId = e.pointerId;
+    this._swipeStartX = e.clientX;
+    this._swipeStartY = e.clientY;
+    this._swipeCurrentDx = 0;
+    const rect = (e.currentTarget as HTMLElement).getBoundingClientRect();
+    this._swipeState = { id: alert.id, offset: 0, locked: false, cardWidth: rect.width };
+  }
+
+  private _onSwipePointerMove(alert: WeatherAlert, e: PointerEvent): void {
+    if (!this._swipeState || this._swipeState.id !== alert.id) return;
+    if (e.pointerId !== this._swipePointerId) return;
+
+    const dx = e.clientX - this._swipeStartX;
+    const dy = e.clientY - this._swipeStartY;
+
+    if (!this._swipeState.locked) {
+      if (Math.abs(dy) - Math.abs(dx) > 12) {
+        this._swipeState = null;
+        return;
+      }
+      if (dx >= 0) {
+        this._swipeState = null;
+        return;
+      }
+      // Capture so the gesture survives the pointer leaving the card; the
+      // rAF below schedules the lock-class + offset DOM update together on
+      // the next frame — no separate requestUpdate() needed here.
+      (e.currentTarget as HTMLElement).setPointerCapture(e.pointerId);
+      this._swipeState = { ...this._swipeState, locked: true };
+    }
+
+    this._swipeCurrentDx = Math.min(0, dx);
+
+    if (this._swipeRAF !== null) return;
+    this._swipeRAF = requestAnimationFrame(() => {
+      this._swipeRAF = null;
+      if (!this._swipeState || this._swipeState.id !== alert.id) return;
+      this._swipeState = { ...this._swipeState, offset: this._swipeCurrentDx };
+      this.requestUpdate();
+    });
+  }
+
+  private _onSwipePointerUp(alert: WeatherAlert, e: PointerEvent): void {
+    if (!this._swipeState || this._swipeState.id !== alert.id) return;
+    if (e.pointerId !== this._swipePointerId) return;
+    const target = e.currentTarget as HTMLElement;
+    if (target.hasPointerCapture(e.pointerId)) target.releasePointerCapture(e.pointerId);
+    if (this._swipeRAF !== null) {
+      cancelAnimationFrame(this._swipeRAF);
+      this._swipeRAF = null;
+    }
+    const { offset, cardWidth, locked } = this._swipeState;
+    this._swipeState = null;
+    this._swipePointerId = null;
+    if (locked) {
+      // Suppress the synthesized click that follows a mouse drag, so the
+      // header's @click=_toggleDetails doesn't fire after a swipe. Auto-clears
+      // next tick in case the browser doesn't fire a click at all.
+      this._swipeJustDragged = true;
+      setTimeout(() => { this._swipeJustDragged = false; }, 0);
+    }
+    if (locked && offset <= -(cardWidth * 0.4)) {
+      this._swipeExiting = alert.id;
+      const delay = this._motionQuery.matches ? 0 : 200;
+      this._swipeExitTimeout = window.setTimeout(() => {
+        this._swipeExitTimeout = null;
+        this._swipeExiting = null;
+        this._onDismiss(alert);
+      }, delay);
+    } else {
+      this.requestUpdate();
+    }
+  }
+
+  private _onSwipePointerCancel(alert: WeatherAlert, e: PointerEvent): void {
+    if (!this._swipeState || this._swipeState.id !== alert.id) return;
+    if (e.pointerId !== this._swipePointerId) return;
+    const target = e.currentTarget as HTMLElement;
+    if (target.hasPointerCapture(e.pointerId)) target.releasePointerCapture(e.pointerId);
+    if (this._swipeRAF !== null) {
+      cancelAnimationFrame(this._swipeRAF);
+      this._swipeRAF = null;
+    }
+    this._swipeState = null;
+    this._swipePointerId = null;
+    this.requestUpdate();
+  }
+
+  private _swipeCardStyle(alert: WeatherAlert, baseStyle: string): string {
+    if (this._swipeExiting === alert.id) return baseStyle;
+    if (this._swipeState?.id === alert.id) {
+      const { offset, cardWidth } = this._swipeState;
+      const opacity = Math.max(0, 1 + offset / cardWidth).toFixed(2);
+      return `${baseStyle} transform: translateX(${offset}px); opacity: ${opacity};`;
+    }
+    return baseStyle;
+  }
+
+  private _swipeCardClass(alert: WeatherAlert): string {
+    const classes: string[] = [];
+    if (this._swipeEnabled()) classes.push('swipe-enabled');
+    if (this._swipeExiting === alert.id) classes.push('swipe-exit');
+    else if (this._swipeState?.id === alert.id && this._swipeState.locked) classes.push('swiping');
+    return classes.join(' ');
+  }
+
+  private _isLabeledDismissActive(): boolean {
+    return this._canDismiss()
+      && this._config?.dismissTrigger !== 'swipe'
+      && this._config?.dismissButtonStyle === 'labeled'
+      && !this._isCompact;
+  }
+
   private _renderDismissButton(alert: WeatherAlert): TemplateResult | typeof nothing {
     if (!this._canDismiss()) return nothing;
+    if (this._config?.dismissTrigger === 'swipe') return nothing;
+    if (this._isLabeledDismissActive()) {
+      return html`
+        <button
+          type="button"
+          class="dismiss-button labeled"
+          aria-label=${t('card.dismiss', this._lang)}
+          title=${t('card.dismiss', this._lang)}
+          @click=${(e: Event) => { e.stopPropagation(); this._onDismiss(alert); }}
+        >
+          <ha-icon icon="mdi:close"></ha-icon>
+          <span>${t('card.dismiss', this._lang)}</span>
+        </button>
+      `;
+    }
     return html`
       <button
         type="button"
@@ -593,6 +754,12 @@ export class WeatherAlertsCard extends LitElement {
   }
 
   private _toggleDetails(alertId: string): void {
+    // A click synthesized at the end of a successful pointer drag would
+    // otherwise toggle the alert that was just swiped — swallow it.
+    if (this._swipeJustDragged) {
+      this._swipeJustDragged = false;
+      return;
+    }
     const next = new Map(this._expandedAlerts);
     next.set(alertId, !next.get(alertId));
     this._expandedAlerts = next;
@@ -710,8 +877,17 @@ export class WeatherAlertsCard extends LitElement {
     const ongoingClass = isOngoing ? 'ongoing' : '';
     const boostClasses = this._alertBoostClasses(alert);
     const progressStyle = isOngoing ? '' : `--progress: ${progress.progressPct}%;`;
+    const swipeClass = this._swipeCardClass(alert);
+    const cardStyle = this._swipeCardStyle(alert, `${this._alertColorStyle(alert)} ${progressStyle}`);
     return html`
-      <div class="alert-card ${className} ${phaseClass} ${ongoingClass} ${boostClasses}" style=${`${this._alertColorStyle(alert)} ${progressStyle}`}>
+      <div
+        class="alert-card ${className} ${phaseClass} ${ongoingClass} ${boostClasses} ${swipeClass}"
+        style=${cardStyle}
+        @pointerdown=${(e: PointerEvent) => this._onSwipePointerDown(alert, e)}
+        @pointermove=${(e: PointerEvent) => this._onSwipePointerMove(alert, e)}
+        @pointerup=${(e: PointerEvent) => this._onSwipePointerUp(alert, e)}
+        @pointercancel=${(e: PointerEvent) => this._onSwipePointerCancel(alert, e)}
+      >
         <div
           class="alert-header-row compact-row"
           @click=${() => this._toggleDetails(alert.id)}
@@ -777,8 +953,17 @@ export class WeatherAlertsCard extends LitElement {
     progress: AlertProgress, expanded: boolean,
   ): TemplateResult {
     const boostClasses = this._alertBoostClasses(alert);
+    const swipeClass = this._swipeCardClass(alert);
+    const cardStyle = this._swipeCardStyle(alert, this._alertColorStyle(alert));
     return html`
-      <div class="alert-card ${className} ${phaseClass} ${boostClasses}" style=${this._alertColorStyle(alert)}>
+      <div
+        class="alert-card ${className} ${phaseClass} ${boostClasses} ${swipeClass}"
+        style=${cardStyle}
+        @pointerdown=${(e: PointerEvent) => this._onSwipePointerDown(alert, e)}
+        @pointermove=${(e: PointerEvent) => this._onSwipePointerMove(alert, e)}
+        @pointerup=${(e: PointerEvent) => this._onSwipePointerUp(alert, e)}
+        @pointercancel=${(e: PointerEvent) => this._onSwipePointerCancel(alert, e)}
+      >
         <div class="alert-header-row">
           <div class="icon-box">
             <ha-icon icon=${alert.providerIcon ?? getWeatherIcon(alert.iconHint || alert.event)}></ha-icon>


### PR DESCRIPTION
## Summary

- Adds two config options under a dedicated **Dismissal** editor section: `dismissTrigger` (`button` / `swipe` / `both`) and `dismissButtonStyle` (`icon` / `labeled`).
- Unifies touch swipe and mouse click-drag on one Pointer Events code path — drag past 40% of card width to dismiss, spring-back otherwise, honors `prefers-reduced-motion`.
- Reworks dismiss-button placement as window-decoration: both icon-only and labeled variants are corner-tucked at the card's top-right, out of the flex flow, so title / headline / area-desc / badges flow the full row width. The labeled variant nests flush against the card's rounded corner using only inner-edge strokes.

## Test plan

- [x] **Editor surface**: open the card editor, toggle `allowDismiss` → the **Dismissal** section reveals `dismissTrigger` and `dismissButtonStyle` selects. Selecting `dismissTrigger: 'swipe'` hides the button-style select.
- [x] **Icon-only, default**: with `allowDismiss: true` and defaults, the × icon sits at top-right corner of each card; title flows full width.
- [x] **Labeled pill**: set `dismissButtonStyle: 'labeled'` → tucked-in corner badge with inner-edge strokes; "Dismiss" label in all five locales (en/fr/es/it/de).
- [x] **Compact layout**: button stays inline at row-end in compact mode (no corner tuck); labeled style falls back to icon-only.
- [x] **Touch swipe (mobile)**: left-swipe past 40% dismisses; under threshold springs back; vertical scroll still works during deliberation phase.
- [x] **Mouse drag (desktop)**: left-click-drag the card horizontally past 40% dismisses; cursor changes to `grab` / `grabbing`; click without drag still toggles details.
- [x] **`dismissTrigger: 'swipe'`**: button is hidden; both touch swipe and mouse drag remain operable for KBM users.
- [x] **Reduced motion**: with OS `prefers-reduced-motion: reduce`, swipe-exit animation is suppressed (immediate dismissal).
- [x] **Undo toast**: `showDismissUndo` toast still fires from both swipe and button paths.
- [x] **Theming**: labeled pill colors track `--divider-color` / `--secondary-text-color`; hover uses neutral `--rgb-primary-text-color`. No accent color competition with severity stripe.

Closes #151

🤖 Generated with [Claude Code](https://claude.com/claude-code)