### PR TITLE
chore: add ECCC color theme column to themes screenshot

### DIFF
--- a/scripts/screenshot-fixtures.js
+++ b/scripts/screenshot-fixtures.js
@@ -207,6 +207,64 @@ export const ALERTS_CONTRAST_DEMO = [
   makeContrastAlert('c9', 'Freeze Watch',                'Minor',    'Northfield',   watchTiming),
 ];
 
+// ECCC-format alerts covering all four active color tiers (red/orange/yellow/grey).
+// Uses the EcccAlert shape consumed by EcccAdapter: attribution on the entity
+// attributes, alerts array with ECCC fields.
+export const ECCC_ALERTS = [
+  {
+    title: 'Rainfall Warning',
+    color: 'red',
+    type: 'warning',
+    impact: 'High',
+    confidence: 'High',
+    status: 'new',
+    alert_code: 'RWW',
+    area: 'Sampletown - Demoville',
+    issued: new Date(now - 2 * H).toISOString(),
+    expiry: new Date(now + 1.5 * H).toISOString(),
+    text: 'Heavy rainfall warning in effect. Sample data for demonstration purposes.',
+  },
+  {
+    title: 'Wind Warning',
+    color: 'orange',
+    type: 'warning',
+    impact: 'High',
+    confidence: 'High',
+    status: 'continued',
+    alert_code: 'WW',
+    area: 'Mockton County',
+    issued: new Date(now - 1 * H).toISOString(),
+    expiry: new Date(now + 4 * H).toISOString(),
+    text: 'Strong wind warning in effect. Sample data for demonstration purposes.',
+  },
+  {
+    title: 'Winter Storm Watch',
+    color: 'yellow',
+    type: 'watch',
+    impact: 'Medium',
+    confidence: 'Moderate',
+    status: 'new',
+    alert_code: 'WSW',
+    area: 'Northern Placeholder Highlands',
+    issued: new Date(now - 0.5 * H).toISOString(),
+    expiry: new Date(now + 10 * H).toISOString(),
+    text: 'Winter storm watch in effect. Sample data for demonstration purposes.',
+  },
+  {
+    title: 'Special Weather Statement',
+    color: 'grey',
+    type: 'statement',
+    impact: 'Low',
+    confidence: 'Moderate',
+    status: 'new',
+    alert_code: 'SWS',
+    area: 'Greater Exampleville Region',
+    issued: new Date(now - 0.25 * H).toISOString(),
+    expiry: new Date(now + 12 * H).toISOString(),
+    text: 'Special weather statement in effect. Sample data for demonstration purposes.',
+  },
+];
+
 // PirateWeather-format duplicates of some NWS alerts (for cross-provider dedup demos).
 // Uses the PirateWeather indexed attribute format (title_0, severity_0, etc.)
 // with matching event names and expiry times so the card's dedup logic merges them.

--- a/scripts/screenshot-themes.html
+++ b/scripts/screenshot-themes.html
@@ -60,7 +60,7 @@
       padding: 36px 28px 28px;
       display: flex;
       gap: 24px;
-      width: 1100px;
+      width: 1460px;
     }
 
     /* Each showcase column */
@@ -128,11 +128,21 @@
       </div>
     </div>
 
+    <!-- ECCC theme: compact layout -->
+    <div class="showcase">
+      <div class="section-label">ECCC</div>
+      <div class="card-wrapper">
+        <div class="card-inner">
+          <weather-alerts-card id="card-eccc"></weather-alerts-card>
+        </div>
+      </div>
+    </div>
+
   </div>
 
   <script type="module">
     import '/dist/weather-alerts-card.js';
-    import { ALERTS_WITH_MINOR } from '/scripts/screenshot-fixtures.js';
+    import { ALERTS_WITH_MINOR, ECCC_ALERTS } from '/scripts/screenshot-fixtures.js';
 
     // ---- ha-card stub ----
     class HaCard extends HTMLElement {
@@ -186,7 +196,7 @@
     }
     customElements.define('ha-icon', HaIcon);
 
-    // ---- Mock hass — all four alerts for every card ----
+    // ---- Mock hass — alerts for every card ----
     const MOCK_HASS = {
       locale: { language: 'en', time_format: '12', date_format: 'MDY' },
       config: { time_zone: 'America/Denver' },
@@ -195,10 +205,18 @@
           state: String(ALERTS_WITH_MINOR.length),
           attributes: { Alerts: ALERTS_WITH_MINOR },
         },
+        'sensor.eccc_alerts': {
+          state: String(ECCC_ALERTS.length),
+          attributes: {
+            attribution: 'Environment Canada',
+            alerts: ECCC_ALERTS,
+          },
+        },
       },
     };
 
     const ENTITY = 'sensor.nws_alerts_alerts';
+    const ECCC_ENTITY = 'sensor.eccc_alerts';
 
     // ---- Wire up cards — all compact, different color themes ----
     const severity = document.getElementById('card-severity');
@@ -212,6 +230,10 @@
     const meteoalarm = document.getElementById('card-meteoalarm');
     meteoalarm.setConfig({ type: 'custom:weather-alerts-card', entity: ENTITY, animations: false, colorTheme: 'meteoalarm', layout: 'compact' });
     meteoalarm.hass = MOCK_HASS;
+
+    const eccc = document.getElementById('card-eccc');
+    eccc.setConfig({ type: 'custom:weather-alerts-card', entity: ECCC_ENTITY, animations: false, colorTheme: 'eccc', layout: 'compact' });
+    eccc.hass = MOCK_HASS;
   </script>
 </body>
 </html>


### PR DESCRIPTION
## Summary

- Adds a fourth column (`ECCC`) to `screenshot-themes.html`, expanding the canvas from 1100px to 1460px
- Adds `ECCC_ALERTS` fixture to `screenshot-fixtures.js` — four ECCC-format alerts covering all active color tiers: red (Rainfall Warning), orange (Wind Warning), yellow (Winter Storm Watch), grey (Special Weather Statement)
- Wires up `#card-eccc` with `colorTheme: 'eccc'` pointing at a dedicated `sensor.eccc_alerts` mock entity with `attribution: 'Environment Canada'`

## Test plan

- [x] Build the project and serve `screenshot-themes.html` — verify four columns render with correct per-theme colors
- [x] Run `scripts/screenshot.js` (or equivalent) and confirm the generated themes screenshot includes the ECCC column
- [x] Light and dark captures both look correct

🤖 Generated with [Claude Code](https://claude.com/claude-code)