### PR TITLE
fix(cap): suppress URN identifiers from source link

### DIFF
--- a/src/adapters/cap.ts
+++ b/src/adapters/cap.ts
@@ -49,7 +49,7 @@ export class CapAdapter implements AlertAdapter {
       endsTs,
       description: str(attributes['description']),
       instruction: str(attributes['instruction']),
-      url: str(attributes['url']) || str(attributes['web']),
+      url: httpUrl(str(attributes['url'])) || httpUrl(str(attributes['web'])),
       headline: str(attributes['headline']),
       areaDesc: str(attributes['area_desc']),
       zones: collectZones(attributes),
@@ -94,4 +94,8 @@ function collectZones(attributes: Record<string, unknown>): string[] {
 
 function str(v: unknown): string {
   return typeof v === 'string' ? v : '';
+}
+
+function httpUrl(v: string): string {
+  return v.startsWith('http://') || v.startsWith('https://') ? v : '';
 }


### PR DESCRIPTION
## Summary

- CAP Alerts integration sets `url` to a `urn:oid:…` identifier, not a navigable HTTP address
- The card was rendering this as an "Open CAP Source" link that goes nowhere
- Added an `httpUrl()` guard in the CAP adapter that accepts only `http://`/`https://` values — URNs produce an empty string, hiding the footer link entirely

## Test plan

- [x] With a CAP alert entity whose `url` attribute is a `urn:` value, confirm the "Open CAP Source" link is no longer shown
- [x] With a CAP alert entity whose `url` attribute is a real `https://` URL, confirm the source link still appears and navigates correctly
- [x] CAP alerts with no `url`/`web` attributes continue to show no link (no regression)

🤖 Generated with [Claude Code](https://claude.com/claude-code)