### PR TITLE
fix: address audit findings (perf, render purity, filter safety, robustness)

### DIFF
--- a/README.md
+++ b/README.md
@@ -260,7 +260,7 @@ Severity and certainty badges are always localized to your configured language. 
 | BoM | Inferred (parsed from title/type/group) | Absent |
 | MeteoAlarm | Raw (from `awareness_level` or `severity`) | Raw (from `certainty`) |
 | DWD | Raw (from integer `level`) | Absent |
-| ECCC | Inferred (max of `color`/`type`/`impact`) | Raw (from `confidence` field) |
+| ECCC | Derived (max of `color`, `type`, `impact`; tilde only when all three absent) | Mapped from `confidence` (High → Likely, Moderate → Possible, Low → Unlikely) |
 | PirateWeather | Raw (from `severity` field) | Absent |
 | CAP Alerts | Raw (from `severity_normalized` / `severity`) | Raw (from `certainty` field) |
 

--- a/README.md
+++ b/README.md
@@ -13,9 +13,10 @@ A custom Home Assistant Lovelace card for displaying weather alerts with severit
 - **Expandable details** — sanitized description, instructions, and source link
 - **BoM phase badges** — New, Updated, Renewed lifecycle indicators
 - **Compact layout** — collapsed single-row alerts with progress bars that expand on tap
-- **Zone filtering (BoM)** — show only alerts for specific `area_id` zones
+- **Zone filtering** — show only alerts for specific zone codes (BoM `area_id`, NWS UGC)
+- **Dismissable alerts** — optional per-alert dismiss (button or swipe) with undo and a restore-all control, stored browser-locally
 - **Sort order** — default, onset time, or severity
-- **Severity threshold** — minimum severity to display
+- **Severity threshold** — minimum severity to display (unclassified alerts always shown)
 - **Localized UI** — English, French, Spanish, Italian, and German; auto-detected from Home Assistant locale
 - **Visual config** — no YAML editing required
 
@@ -52,9 +53,9 @@ Then click the Download button, and click Reload when prompted.
 | `device` | — | HA `device_id` — auto-discovers all per-alert sensors under that device and re-discovers as alerts come and go. Currently only the CAP Alerts integration uses this shape. Can be combined with `entity`/`entities` or used on its own. |
 | `provider` | auto-detect | `'nws'`, `'bom'`, `'meteoalarm'`, `'dwd'`, `'eccc'`, `'pirateweather'`, `'cap'` |
 | `title` | — | Card header title |
-| `zones` | — | BoM `area_id` codes to filter (e.g. `NSW_FL049`) |
+| `zones` | — | Zone codes to filter — BoM `area_id` (e.g. `NSW_FL049`) or NWS UGC (e.g. `COZ039`) |
 | `sortOrder` | `'default'` | `'default'`, `'onset'`, `'severity'` |
-| `minSeverity` | `'all'` | `'all'`, `'minor'`, `'moderate'`, `'severe'`, `'extreme'` |
+| `minSeverity` | `'all'` | `'all'`, `'minor'`, `'moderate'`, `'severe'`, `'extreme'`. Alerts whose severity is unknown/unclassified are always shown, regardless of this threshold |
 | `colorTheme` | `'severity'` | `'severity'`, `'nws'`, `'meteoalarm'`, `'eccc'` — `'eccc'` uses ECCC's published `red`/`orange`/`yellow`/`grey` palette (matches weather.gc.ca); falls back to the canonical severity tier for non-ECCC alerts displayed under this theme |
 | `enhanceContrast` | `'subtle'` | `'off'`, `'subtle'`, `'strict'` — boost foreground colors for NWS/MeteoAlarm events whose raw hex reads poorly against the active theme's card background, applied per event, per theme mode, and only in the direction where it fails. `'subtle'` (default) uses a text tier (~2:1 for icon/label) and a stricter progress tier (~1.3:1 for progress-bar fill, which catches near-invisible tints like yellow Tornado Watch). `'strict'` tightens both tiers (text ~3:1, progress ~2:1) toward WCAG AA-ish guarantees. `'off'` always renders raw theme hex values. Events that already read cleanly (e.g. Tornado Warning) render unchanged in all modes. |
 | `eventCodes` | — | Event codes to include, e.g. `['SVR', 'TOR']` (NWS) or `['31', '95']` (DWD) |
@@ -75,6 +76,10 @@ Then click the Download button, and click Reload when prompted.
 | `fontSize` | `'default'` | `'small'`, `'default'`, `'large'`, `'x-large'` — scales text and icons |
 | `reformatText` | `true` | Strip hard line wraps from alert text (NWS 69-char teletype breaks) while preserving paragraph breaks |
 | `layout` | `'default'` | `'default'` or `'compact'` |
+| `allowDismiss` | `false` | Let users dismiss individual alerts (browser-local). Adds a × button and/or swipe gesture |
+| `dismissTrigger` | `'button'` | `'button'`, `'swipe'`, or `'both'` — how an alert is dismissed (swipe covers touch + mouse drag). Requires `allowDismiss` |
+| `dismissButtonStyle` | `'icon'` | `'icon'` or `'labeled'` (icon + "Dismiss" text). No effect when `dismissTrigger: 'swipe'`; compact layout is always icon-only |
+| `showDismissUndo` | `true` | Show an Undo toast when an alert is dismissed. No effect when `allowDismiss` is off |
 
 <details>
 <summary><strong>Examples</strong></summary>
@@ -233,6 +238,17 @@ card_mod:
 </details>
 
 </details>
+
+### Dismissing alerts
+
+Set `allowDismiss: true` to let users clear individual alerts from view. Dismissals are **browser-local** — stored in that browser only, scoped to the card's configured entity/device set. They never touch the integration or sync to other devices, and an alert automatically re-surfaces if it is re-issued or its severity/timing changes. The visual editor's **Dismissal** section shows how many alerts are currently dismissed and offers a **Restore all** action.
+
+```yaml
+type: custom:weather-alerts-card
+entity: sensor.nws_alerts_alerts
+allowDismiss: true
+dismissTrigger: both   # 'button' (default), 'swipe', or 'both'
+```
 
 ## Supported Providers
 

--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ A custom Home Assistant Lovelace card for displaying weather alerts with severit
 - **Expandable details** — sanitized description, instructions, and source link
 - **BoM phase badges** — New, Updated, Renewed lifecycle indicators
 - **Compact layout** — collapsed single-row alerts with progress bars that expand on tap
-- **Zone filtering** — show only alerts for specific zone codes (BoM `area_id`, NWS UGC)
+- **Zone filtering (BoM)** — show only alerts for specific `area_id` zones
 - **Dismissable alerts** — optional per-alert dismiss (button or swipe) with undo and a restore-all control, stored browser-locally
 - **Sort order** — default, onset time, or severity
 - **Severity threshold** — minimum severity to display (unclassified alerts always shown)
@@ -53,7 +53,7 @@ Then click the Download button, and click Reload when prompted.
 | `device` | — | HA `device_id` — auto-discovers all per-alert sensors under that device and re-discovers as alerts come and go. Currently only the CAP Alerts integration uses this shape. Can be combined with `entity`/`entities` or used on its own. |
 | `provider` | auto-detect | `'nws'`, `'bom'`, `'meteoalarm'`, `'dwd'`, `'eccc'`, `'pirateweather'`, `'cap'` |
 | `title` | — | Card header title |
-| `zones` | — | Zone codes to filter — BoM `area_id` (e.g. `NSW_FL049`) or NWS UGC (e.g. `COZ039`) |
+| `zones` | — | BoM `area_id` codes to filter (e.g. `NSW_FL049`) |
 | `sortOrder` | `'default'` | `'default'`, `'onset'`, `'severity'` |
 | `minSeverity` | `'all'` | `'all'`, `'minor'`, `'moderate'`, `'severe'`, `'extreme'`. Alerts whose severity is unknown/unclassified are always shown, regardless of this threshold |
 | `colorTheme` | `'severity'` | `'severity'`, `'nws'`, `'meteoalarm'`, `'eccc'` — `'eccc'` uses ECCC's published `red`/`orange`/`yellow`/`grey` palette (matches weather.gc.ca); falls back to the canonical severity tier for non-ECCC alerts displayed under this theme |
@@ -238,17 +238,6 @@ card_mod:
 </details>
 
 </details>
-
-### Dismissing alerts
-
-Set `allowDismiss: true` to let users clear individual alerts from view. Dismissals are **browser-local** — stored in that browser only, scoped to the card's configured entity/device set. They never touch the integration or sync to other devices, and an alert automatically re-surfaces if it is re-issued or its severity/timing changes. The visual editor's **Dismissal** section shows how many alerts are currently dismissed and offers a **Restore all** action.
-
-```yaml
-type: custom:weather-alerts-card
-entity: sensor.nws_alerts_alerts
-allowDismiss: true
-dismissTrigger: both   # 'button' (default), 'swipe', or 'both'
-```
 
 ## Supported Providers
 

--- a/scripts/testing-zones.sh
+++ b/scripts/testing-zones.sh
@@ -306,8 +306,13 @@ nws() {
 }
 
 # ─── BoM ──────────────────────────────────────────────────────────────────────
-# BoM warnings have no geometry — we extract a place name from the warning
-# title, resolve it via the BoM locations API, and decode the geohash locally.
+# BoM warnings carry no geometry. The HA integration calls
+# /v1/locations/{geohash}/warnings, so the recommended location must fall
+# within an active warning area. We:
+#   1. Extract candidate place names from warning titles (multi-pattern).
+#   2. Resolve each via the BoM locations API.
+#   3. Verify via /v1/locations/{geohash}/warnings (same endpoint HA uses).
+#   4. Return the first location that is confirmed to have active warnings.
 
 decode_geohash() {
   echo "$1" | awk '
@@ -333,8 +338,20 @@ decode_geohash() {
 
 extract_bom_places() {
   local title="$1"
-  echo "$title" | grep -oP '(?<= at )\w+' || true
-  echo "$title" | cut -d, -f1 | sed 's/\b\(River\|Creek\|Bay\|Lake\|Range\)\b//g; s/^ *//; s/ *$//'
+  # Specific location after "at" (e.g. "Flood Warning for Murray River at Albury")
+  echo "$title" | grep -oP '(?<= at )[A-Z]\w+' || true
+  # Strip the warning-type prefix to get just the area description
+  local area
+  area=$(echo "$title" | sed -E 's/^.*(Warning|Watch|Advice|Advisory) for (the )?//')
+  # Directional+city patterns: "Greater Sydney", "Central Coast", etc. → "Sydney", "Coast"
+  echo "$area" | grep -oP '(?:Greater|Central|Northern|Southern|Western|Eastern|Inner|Outer|Upper|Lower|Far North|South East|North East) +([A-Z][a-z]+(?:(?: [A-Z][a-z]+)*)?)' \
+    | grep -oP '[A-Z][a-z]+(?:(?: [A-Z][a-z]+)*)$' || true
+  # "X Region / District / Coast / Valley / Basin" → "X"
+  echo "$area" | grep -oP '\b([A-Z][a-z]+(?:(?: [A-Z][a-z]+)+)?)\b(?=\s+(?:Region|District|Coast|Valley|Basin|Peninsula|Ranges|Plateau))' || true
+  # All capitalised words (skip common weather/geographic noise) — broadest fallback
+  echo "$area" | grep -oP '\b[A-Z][a-z]{2,}\b' \
+    | grep -iv 'Warning\|Watch\|Advice\|Advisory\|Region\|District\|Coast\|Valley\|Basin\|Peninsula\|Ranges\|Plateau\|Catchment\|River\|Creek\|Bay\|Lake\|Range\|Weather\|Flood\|Storm\|Fire\|Wind\|Rain\|Hail\|Thunder\|Cyclone\|Tropical\|Severe\|Major\|Minor\|Moderate\|Extreme\|Initial\|Final\|Update\|Australia\|Territory\|State' \
+    || true
 }
 
 bom_search_place() {
@@ -345,6 +362,37 @@ bom_search_place() {
   echo "$result" | jq -r --arg st "$target_state" '
     (.data[] | select(.state == $st) | "\(.geohash)\t\(.name)") // empty
   ' | head -1
+}
+
+# Search for a place and return the first land-based result whose geohash is
+# confirmed to have active warnings via /v1/locations/{geohash}/warnings.
+#
+# "Land-based" = BoM location has a postcode. Marine/offshore stations have no
+# postcode, and their geohash centroids typically fall in the ocean.
+#
+# Prints: "geohash\tname\tlat\tlon\tcount" on success, nothing on failure.
+# lat/lon come from the API directly (more accurate than geohash centroid).
+bom_search_verified() {
+  local place="$1" target_state="$2"
+  local search_result
+  search_result=$(curl -sf --max-time 10 -H "User-Agent: $UA" \
+    "https://api.weather.bom.gov.au/v1/locations?search=$(echo "$place" | sed 's/ /%20/g')" 2>/dev/null) || return 1
+
+  # Only land-based locations (postcode present); iterate in API order.
+  while IFS=$'\t' read -r gh name lat lon; do
+    [ -z "$gh" ] && continue
+    local check count
+    check=$(curl -sf --max-time 10 -H "User-Agent: $UA" \
+      "https://api.weather.bom.gov.au/v1/locations/${gh}/warnings" 2>/dev/null) || continue
+    count=$(echo "$check" | jq '[.data[] | select(.phase != "cancelled")] | length' 2>/dev/null || echo 0)
+    if [ "$count" -gt 0 ]; then
+      printf '%s\t%s\t%s\t%s\t%s\n' "$gh" "$name" "$lat" "$lon" "$count"
+      return 0
+    fi
+  done < <(echo "$search_result" | jq -r --arg st "$target_state" '
+    [.data[] | select(.state == $st and (.postcode? // "") != "")] |
+    .[] | "\(.geohash)\t\(.name)\t\(.latitude? // "")\t\(.longitude? // "")"
+  ' 2>/dev/null)
 }
 
 bom() {
@@ -358,17 +406,39 @@ bom() {
 
   local total
   total=$(echo "$warnings" | jq '[.data[] | select(.phase != "cancelled")] | length')
-  echo "  Active warnings: $total"
 
   if [ "$total" -eq 0 ]; then
+    echo "  Active warnings: 0"
     echo "  No active warnings."
     return 0
   fi
 
-  # Per-state diversity analysis
+  # Marine warnings (type contains "marine") appear in the coverage totals but are
+  # not useful for HA land-integration testing: the integration's point-in-polygon
+  # query never matches offshore/marine station geohashes for these alerts.
+  local land_warnings land_total marine_total
+  land_warnings=$(echo "$warnings" | jq '[.data[] | select(.phase != "cancelled" and (.type | test("marine"; "i") | not))]')
+  land_total=$(echo "$land_warnings" | jq 'length')
+  marine_total=$((total - land_total))
+
+  echo "  Active warnings: $total  ($land_total land-based, $marine_total marine/coastal)"
+
+  if [ "$land_total" -eq 0 ]; then
+    echo ""
+    echo "  All active warnings are marine/coastal — not suitable for HA land-integration"
+    echo "  testing. Run again when Australia has active flood, storm, or fire warnings."
+    echo ""
+    echo "  ── Condition coverage (all $total warnings) ──"
+    echo "$warnings" | jq -r '
+      [.data[] | select(.phase != "cancelled")] |
+      "  By type:  \(group_by(.type) | map("\(.[0].type)=\(length)") | join("  "))"
+    '
+    return 0
+  fi
+
+  # Per-state diversity analysis — land warnings only.
   local state_analysis
-  state_analysis=$(echo "$warnings" | jq '
-    [.data[] | select(.phase != "cancelled")] |
+  state_analysis=$(echo "$land_warnings" | jq '
     group_by(.state) | map(
       . as $arr |
       {
@@ -393,7 +463,7 @@ bom() {
     <<< "$(echo "$state_analysis" | jq -r '.[0] | [.state, .score, .count, (.phases|join(", ")), (.groups|join(", ")), (.types|join(", "))] | @tsv')"
 
   echo ""
-  echo "  ── Best testing state (score: $best_score) ──"
+  echo "  ── Best testing state (score: $best_score, land warnings only) ──"
   echo ""
   echo "  state:          $best_state"
   echo "  warnings:       $best_count"
@@ -411,77 +481,106 @@ bom() {
   # Sample warnings from best state
   echo ""
   echo "  ── Sample warnings from $best_state ──"
-  echo "$warnings" | jq -r --arg st "$best_state" '
-    [.data[] | select(.state == $st and .phase != "cancelled")] |
+  echo "$land_warnings" | jq -r --arg st "$best_state" '
+    [.[] | select(.state == $st)] |
     .[0:6] | .[] |
     "    [\(.phase)] \(.title) (\(.type), \(.warning_group_type))"
   '
 
-  # Resolve a location for the best state
-  local lat="?" lon="?" resolved_name=""
+  # Find a BoM location that is confirmed to have active warnings.
+  # Tries place names from up to 5 warning titles; verifies each candidate via
+  # /v1/locations/{geohash}/warnings (the same call the HA integration makes).
+  local lat="?" lon="?" resolved_name="" bom_geohash="" bom_warning_count=0
   echo ""
-  echo "  Resolving location..."
+  echo "  Searching for a verified location with active warnings..."
 
-  local sample_title
-  sample_title=$(echo "$warnings" | jq -r --arg st "$best_state" '
-    [.data[] | select(.state == $st and .phase != "cancelled")] | .[0].title // ""
+  local found_verified=""
+  while IFS= read -r wtitle; do
+    [ -z "$wtitle" ] && continue
+    local places
+    places=$(extract_bom_places "$wtitle")
+    while IFS= read -r place; do
+      [ -z "$place" ] && continue
+      local match
+      match=$(bom_search_verified "$place" "$best_state") || continue
+      if [ -n "$match" ]; then
+        found_verified="$match"
+        break 2
+      fi
+    done <<< "$places"
+  done < <(echo "$land_warnings" | jq -r --arg st "$best_state" '
+    [.[] | select(.state == $st)] | .[0:5] | .[].title
   ')
 
-  local places found=""
-  places=$(extract_bom_places "$sample_title")
-  while IFS= read -r place; do
-    [ -z "$place" ] && continue
-    local match
-    match=$(bom_search_place "$place" "$best_state") || continue
-    if [ -n "$match" ]; then
-      found="$match"
-      break
+  if [ -n "$found_verified" ]; then
+    bom_geohash=$(echo "$found_verified" | cut -f1)
+    resolved_name=$(echo "$found_verified" | cut -f2)
+    local api_lat api_lon
+    api_lat=$(echo "$found_verified" | cut -f3)
+    api_lon=$(echo "$found_verified" | cut -f4)
+    bom_warning_count=$(echo "$found_verified" | cut -f5)
+    # Prefer coordinates from the API over the geohash centroid (more accurate for coastal towns)
+    if [ -n "$api_lat" ] && [ "$api_lat" != "null" ] && [ "$api_lat" != "" ]; then
+      lat="$api_lat"; lon="$api_lon"
+    else
+      read -r lat lon < <(decode_geohash "$bom_geohash")
     fi
-  done <<< "$places"
-
-  if [ -n "$found" ]; then
-    local geohash
-    geohash=$(echo "$found" | cut -f1)
-    resolved_name=$(echo "$found" | cut -f2)
-    read -r lat lon < <(decode_geohash "$geohash")
-    echo "  Resolved: $resolved_name ($geohash)"
+    echo "  Verified: $resolved_name (geohash: $bom_geohash, warnings confirmed: $bom_warning_count)"
   else
-    echo "  Could not resolve a location from title — using state capital"
+    # Nothing verified — try the state capital as a last resort with explicit caveat.
+    echo "  Could not find a verified warning location — using state capital"
+    echo "  (state capital is unlikely to show warnings; use a suburb in the affected area)"
+    local cap_place
     case "$best_state" in
-      NSW) lat="-33.8688"; lon="151.2093"; resolved_name="Sydney" ;;
-      VIC) lat="-37.8136"; lon="144.9631"; resolved_name="Melbourne" ;;
-      QLD) lat="-27.4698"; lon="153.0251"; resolved_name="Brisbane" ;;
-      SA)  lat="-34.9285"; lon="138.6007"; resolved_name="Adelaide" ;;
-      WA)  lat="-31.9505"; lon="115.8605"; resolved_name="Perth" ;;
-      TAS) lat="-42.8821"; lon="147.3272"; resolved_name="Hobart" ;;
-      NT)  lat="-12.4634"; lon="130.8456"; resolved_name="Darwin" ;;
-      ACT) lat="-35.2809"; lon="149.1300"; resolved_name="Canberra" ;;
-      *)   resolved_name="unknown" ;;
+      NSW) cap_place="Sydney" ;;
+      VIC) cap_place="Melbourne" ;;
+      QLD) cap_place="Brisbane" ;;
+      SA)  cap_place="Adelaide" ;;
+      WA)  cap_place="Perth" ;;
+      TAS) cap_place="Hobart" ;;
+      NT)  cap_place="Darwin" ;;
+      ACT) cap_place="Canberra" ;;
+      *)   cap_place="" ;;
     esac
+    if [ -n "$cap_place" ]; then
+      local cap_match
+      cap_match=$(bom_search_place "$cap_place" "$best_state") || true
+      if [ -n "$cap_match" ]; then
+        bom_geohash=$(echo "$cap_match" | cut -f1)
+        resolved_name=$(echo "$cap_match" | cut -f2)
+        read -r lat lon < <(decode_geohash "$bom_geohash")
+      fi
+    fi
   fi
 
   echo ""
-  echo "  place: $resolved_name"
-  echo "  lat:   $lat"
-  echo "  lon:   $lon"
+  echo "  place:   $resolved_name"
+  echo "  geohash: $bom_geohash"
+  echo "  lat:     $lat"
+  echo "  lon:     $lon"
+  if [ "$bom_warning_count" -gt 0 ]; then
+    echo "  warnings at this location: $bom_warning_count (confirmed)"
+  fi
   echo ""
   echo "  HA integration: bureau_of_meteorology"
-  echo "  Configure for a location near $resolved_name, $best_state to pick up warnings"
+  echo "  Search for \"$resolved_name\" when adding the integration"
 
   # Condition coverage
   echo ""
   echo "  ── Condition coverage ──"
-  echo "$warnings" | jq -r '
-    [.data[] | select(.phase != "cancelled")] |
+  echo "$land_warnings" | jq -r '
     {
       total: length,
       phases: (group_by(.phase) | map({phase: .[0].phase, count: length}) | sort_by(-.count)),
       groups: (group_by(.warning_group_type) | map({group: .[0].warning_group_type, count: length}) | sort_by(-.count))
     } |
-    "  Total active warnings: \(.total)",
+    "  Land warnings: \(.total)",
     "  By phase:  \(.phases | map("\(.phase)=\(.count)") | join("  "))",
     "  By group:  \(.groups | map("\(.group)=\(.count)") | join("  "))"
   '
+  if [ "$marine_total" -gt 0 ]; then
+    echo "  Marine/coastal warnings: $marine_total (excluded from analysis)"
+  fi
 }
 
 # ─── MeteoAlarm ───────────────────────────────────────────────────────────────

--- a/src/adapters/bom.ts
+++ b/src/adapters/bom.ts
@@ -75,7 +75,8 @@ export class BomAdapter implements AlertAdapter {
   parseAlerts(attributes: Record<string, unknown>): WeatherAlert[] {
     const raw = attributes['warnings'];
     if (!Array.isArray(raw)) return [];
-    return (raw as BomWarning[])
+    return (raw as unknown[])
+      .filter((w): w is BomWarning => typeof w === 'object' && w !== null)
       .filter(w => w.phase !== 'cancelled')
       .map(w => this._normalize(w));
   }

--- a/src/adapters/nws.ts
+++ b/src/adapters/nws.ts
@@ -8,13 +8,17 @@ function extractZoneCode(url: string): string {
 
 function collectZones(alert: NwsAlert): string[] {
   const zones: string[] = [];
-  if (alert.AffectedZones) {
+  // Guard element types: a single non-string entry (malformed payload from a
+  // future/buggy integration version) must not throw and blank the whole card.
+  if (Array.isArray(alert.AffectedZones)) {
     for (const z of alert.AffectedZones) {
+      if (typeof z !== 'string' || !z) continue;
       zones.push(extractZoneCode(z));
     }
   }
-  if (alert.Geocode?.UGC) {
-    for (const code of alert.Geocode.UGC) {
+  if (Array.isArray(alert.Geocode?.UGC)) {
+    for (const code of alert.Geocode!.UGC!) {
+      if (typeof code !== 'string' || !code) continue;
       const upper = code.toUpperCase();
       if (!zones.includes(upper)) zones.push(upper);
     }
@@ -36,7 +40,11 @@ export class NwsAdapter implements AlertAdapter {
   parseAlerts(attributes: Record<string, unknown>): WeatherAlert[] {
     const raw = attributes['Alerts'];
     if (!Array.isArray(raw)) return [];
-    return (raw as NwsAlert[]).map(a => this._normalize(a));
+    // Skip non-object entries so a single malformed element can't crash
+    // normalization of the rest of the array.
+    return (raw as unknown[])
+      .filter((a): a is NwsAlert => typeof a === 'object' && a !== null)
+      .map(a => this._normalize(a));
   }
 
   private _normalize(a: NwsAlert): WeatherAlert {

--- a/src/dismissal.ts
+++ b/src/dismissal.ts
@@ -57,8 +57,12 @@ function notifyDismissalChange(scope: string): void {
 }
 
 /**
- * Listen for same-tab dismissal-state changes (dismiss, undo, restore-all)
- * scoped to a specific entity-set hash. Returns an unsubscribe function.
+ * Listen for dismissal-state changes (dismiss, undo, restore-all) scoped to a
+ * specific entity-set hash. Returns an unsubscribe function.
+ *
+ * Fires for both same-tab changes (via the in-page CustomEvent) and cross-tab
+ * changes (via the native `storage` event, which only fires in *other* tabs),
+ * so dismissing in one tab updates the dashboard open in another.
  */
 export function subscribeToDismissalChanges(
   scope: string,
@@ -70,8 +74,19 @@ export function subscribeToDismissalChanges(
     if (!detail || detail.scope !== scope) return;
     handler();
   };
+  const key = storageKey(scope);
+  const storageListener = (ev: StorageEvent) => {
+    // ev.key === null when storage was cleared wholesale; otherwise only react
+    // to our own scoped key so unrelated writes don't churn every card.
+    if (ev.key !== null && ev.key !== key) return;
+    handler();
+  };
   window.addEventListener(DISMISSALS_CHANGED_EVENT, listener);
-  return () => window.removeEventListener(DISMISSALS_CHANGED_EVENT, listener);
+  window.addEventListener('storage', storageListener);
+  return () => {
+    window.removeEventListener(DISMISSALS_CHANGED_EVENT, listener);
+    window.removeEventListener('storage', storageListener);
+  };
 }
 
 export function loadDismissals(

--- a/src/dismissal.ts
+++ b/src/dismissal.ts
@@ -37,6 +37,42 @@ export function storageKey(scope: string): string {
   return STORAGE_KEY_PREFIX + scope;
 }
 
+/** Config subset that determines a card's dismissal scope. */
+export interface ScopeConfig {
+  entity?: string;
+  entities?: string[];
+  device?: string;
+}
+
+/**
+ * The dismissal-scope source tokens for a card config: primary entity, any
+ * extra entities, and the device id (prefixed). The card and editor MUST both
+ * derive their scope from this single helper — if they diverge, the editor
+ * loads/clears the wrong storage key and the "restore all" UI silently fails.
+ * In particular a device-mode CAP card has no `entity`, so a tokeniser that
+ * ignores `device` produces an empty scope and never surfaces dismissals.
+ */
+export function configuredScopeTokens(config: ScopeConfig | undefined): string[] {
+  if (!config) return [];
+  const tokens: string[] = [];
+  if (config.entity) tokens.push(config.entity);
+  if (config.entities) {
+    for (const id of config.entities) {
+      if (id) tokens.push(id);
+    }
+  }
+  if (config.device) tokens.push(`device:${config.device}`);
+  return tokens;
+}
+
+/** Scope hash for a card config, or '' when no sources are configured. */
+export function scopeHashForConfig(config: ScopeConfig | undefined): string {
+  const tokens = configuredScopeTokens(config);
+  if (tokens.length === 0) return '';
+  const [primary, ...extras] = tokens;
+  return computeScopeHash(primary, extras);
+}
+
 function safeGetStorage(): Storage | null {
   try {
     return typeof localStorage !== 'undefined' ? localStorage : null;

--- a/src/localize.ts
+++ b/src/localize.ts
@@ -754,7 +754,9 @@ export function t(key: string, lang: string, params?: Record<string, string | nu
 
   if (params) {
     for (const [k, v] of Object.entries(params)) {
-      value = value.replace(`{${k}}`, String(v));
+      // split/join replaces every occurrence — String.replace(str, …) only
+      // replaces the first, which would leave repeated placeholders intact.
+      value = value.split(`{${k}}`).join(String(v));
     }
   }
 

--- a/src/registry.ts
+++ b/src/registry.ts
@@ -81,9 +81,35 @@ export async function subscribeEntityRegistry(
     });
     onChange(result ?? []);
   };
-  const unsubEvents = await conn.subscribeEvents(() => {
+  // entity_registry_updated fires in bursts (integration reloads add/rename
+  // many entities at once). Leading-edge throttle: fetch immediately on the
+  // first event so the UI stays responsive, then coalesce any further events
+  // within the window into a single trailing refetch — so we don't re-pull
+  // the full registry once per entity.
+  let throttleTimer: ReturnType<typeof setTimeout> | null = null;
+  let trailingPending = false;
+  const scheduleFetch = (): void => {
+    if (throttleTimer !== null) {
+      trailingPending = true;
+      return;
+    }
     void fetchAndPush().catch(() => { /* ignore — next event will retry */ });
-  }, 'entity_registry_updated');
+    throttleTimer = setTimeout(() => {
+      throttleTimer = null;
+      if (trailingPending) {
+        trailingPending = false;
+        scheduleFetch();
+      }
+    }, 250);
+  };
+  const unsubEvents = await conn.subscribeEvents(() => scheduleFetch(), 'entity_registry_updated');
   await fetchAndPush();
-  return () => { void unsubEvents(); };
+  return () => {
+    if (throttleTimer !== null) {
+      clearTimeout(throttleTimer);
+      throttleTimer = null;
+    }
+    trailingPending = false;
+    void unsubEvents();
+  };
 }

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -606,6 +606,13 @@ export function deduplicateAlerts(
     representative.zones = [...zoneSet];
     representative.areaDesc = [...areaDescs].join('; ');
     representative.mergedCount = group.length;
+    // Use a stable id derived from the merge key rather than group[0].id.
+    // The group key (event/severity/onset/ends/provider) is invariant to the
+    // order in which the integration emits zone-split alerts, so browser-local
+    // dismissals keyed on this id survive upstream array reordering and
+    // zone-set churn (zones are intentionally excluded from the dismissal
+    // signature, so identity must not depend on them either).
+    representative.id = `merged:${key}`;
     return representative;
   });
 

--- a/src/weather-alerts-card-editor.ts
+++ b/src/weather-alerts-card-editor.ts
@@ -5,7 +5,7 @@ import { HomeAssistant, WeatherAlertsCardConfig, AlertSeverity, ContrastMode, En
 import { canHandleAny, ENTITY_NAME_PATTERNS } from './adapters';
 import { resolveDeviceAlertEntities, subscribeEntityRegistry } from './registry';
 import { t } from './localize';
-import { computeScopeHash, loadDismissals, restoreAll, subscribeToDismissalChanges } from './dismissal';
+import { scopeHashForConfig, loadDismissals, restoreAll, subscribeToDismissalChanges } from './dismissal';
 
 @customElement('weather-alerts-card-editor')
 export class WeatherAlertsCardEditor extends LitElement {
@@ -470,10 +470,11 @@ export class WeatherAlertsCardEditor extends LitElement {
   }
 
   private _currentScopeHash(): string {
-    const ids = this._getSelectedEntities();
-    if (ids.length === 0) return '';
-    const [primary, ...extras] = ids;
-    return computeScopeHash(primary, extras);
+    // Must match the card's scope exactly (entity + entities + device), or the
+    // restore-all UI reads the wrong storage key. Notably, a device-mode CAP
+    // card has no `entity`, so omitting `device` here yields an empty scope and
+    // the dismissed-count/restore-all status never appears.
+    return scopeHashForConfig(this._config);
   }
 
   private _getDismissedCount(): number {

--- a/src/weather-alerts-card-editor.ts
+++ b/src/weather-alerts-card-editor.ts
@@ -52,6 +52,12 @@ export class WeatherAlertsCardEditor extends LitElement {
   }
 
   private _maybeSubscribeRegistry(): void {
+    // Only the device-mode hint reads the entity registry. Don't subscribe
+    // (and refetch the whole registry on every update) for plain entity cards.
+    if (!this._config?.device) {
+      this._teardownRegistrySubscription();
+      return;
+    }
     const conn = this.hass?.connection;
     if (!conn || conn === this._subscribedRegistryConn) return;
     this._unsubscribeRegistry?.();
@@ -99,11 +105,19 @@ export class WeatherAlertsCardEditor extends LitElement {
   }
 
   private _cachedHass?: HomeAssistant;
+  private _cachedConfigKey?: string;
   private _cachedEntityIds?: string[];
 
   private _getMatchingEntityIds(): string[] {
-    if (this._cachedHass === this.hass && this._cachedEntityIds) return this._cachedEntityIds;
+    // Cache is keyed on both hass identity AND the configured entity set:
+    // editing config while hass is unchanged must still surface a newly
+    // configured entity in the list.
+    const configKey = this._getSelectedEntities().join(',');
+    if (this._cachedHass === this.hass && this._cachedConfigKey === configKey && this._cachedEntityIds) {
+      return this._cachedEntityIds;
+    }
     this._cachedHass = this.hass;
+    this._cachedConfigKey = configKey;
     const ids: string[] = [];
     for (const [id, entity] of Object.entries(this.hass.states)) {
       if (!id.startsWith('sensor.') && !id.startsWith('binary_sensor.')) continue;

--- a/src/weather-alerts-card.ts
+++ b/src/weather-alerts-card.ts
@@ -230,12 +230,20 @@ export class WeatherAlertsCard extends LitElement {
     // connection typically becomes available here rather than in
     // connectedCallback. Subscribe lazily and re-subscribe if the
     // connection object swaps (e.g., after a reconnect).
-    if (changed.has('hass') && this.isConnected) {
+    if ((changed.has('hass') || changed.has('_config')) && this.isConnected) {
       this._maybeSubscribeRegistry();
     }
   }
 
   private _maybeSubscribeRegistry(): void {
+    // Only device mode reads the entity registry (to resolve per-alert child
+    // sensors under a device). A plain entity/entities card never touches
+    // _registryEntries, so subscribing would refetch the entire registry on
+    // every entity_registry_updated event for nothing. Gate it.
+    if (!this._config?.device) {
+      this._teardownRegistrySubscription();
+      return;
+    }
     const conn = this.hass?.connection;
     if (!conn || conn === this._subscribedRegistryConn) return;
     // New (or first) connection — drop any prior subscription.
@@ -333,7 +341,10 @@ export class WeatherAlertsCard extends LitElement {
   }
 
   public getCardSize(): number {
-    const alerts = this._getAlerts();
+    // Pass reconcile=false: this is a layout-measurement call from HA's
+    // masonry engine and must not trigger localStorage writes or reactive
+    // state mutations as a side effect.
+    const alerts = this._getAlerts(false);
     const perAlert = this._isCompact ? 1 : 3;
     return Math.max(1, alerts.length * perAlert);
   }
@@ -387,14 +398,18 @@ export class WeatherAlertsCard extends LitElement {
     return [...this._configuredScopeTokens()].sort().join(',');
   }
 
-  private _multiProvider = false;
-
   private _deviceHasAnyEntity(deviceId: string): boolean {
     if (!this.hass) return false;
     return deviceHasAnyEntity(this.hass, deviceId, this._registryEntries);
   }
 
-  private _getAlerts(): WeatherAlert[] {
+  // Set when applyDismissals produces a changed map during render; persisted
+  // out-of-band by _scheduleDismissalReconcile so render() stays free of
+  // localStorage writes and reactive-state mutation.
+  private _pendingDismissals: Map<string, DismissalRecord> | null = null;
+  private _dismissalReconcileScheduled = false;
+
+  private _getAlerts(reconcile = true): WeatherAlert[] {
     if (!this.hass || !this._config) return [];
     const allAlerts: WeatherAlert[] = [];
     const providerPriority: AlertProvider[] = [];
@@ -409,17 +424,36 @@ export class WeatherAlertsCard extends LitElement {
       }
       allAlerts.push(...adapter.parseAlerts(entity.attributes));
     }
-    this._multiProvider = providerPriority.length > 1;
     let filtered = this._filterAndSort(allAlerts, { providerPriority });
     if (this._config.allowDismiss && !this._forcePreview && this._dismissals.size > 0) {
       const { visible, updatedMap } = applyDismissals(filtered, this._dismissals);
-      if (updatedMap !== this._dismissals) {
-        this._dismissals = updatedMap;
-        if (this._dismissalsScope) saveDismissals(this._dismissalsScope, updatedMap);
+      // applyDismissals can change the map (un-dismiss on signature shift,
+      // renew lastSeenAt). Defer the write/state-mutation out of the render &
+      // measurement path so we never mutate reactive state during render() or
+      // touch localStorage from getCardSize().
+      if (reconcile && updatedMap !== this._dismissals) {
+        this._scheduleDismissalReconcile(updatedMap);
       }
       filtered = visible;
     }
     return filtered;
+  }
+
+  private _scheduleDismissalReconcile(updatedMap: Map<string, DismissalRecord>): void {
+    // Each render recomputes updatedMap against the unchanged this._dismissals,
+    // so the latest snapshot is always the one to persist. Coalesce repeated
+    // renders into a single microtask write.
+    this._pendingDismissals = updatedMap;
+    if (this._dismissalReconcileScheduled) return;
+    this._dismissalReconcileScheduled = true;
+    queueMicrotask(() => {
+      this._dismissalReconcileScheduled = false;
+      const next = this._pendingDismissals;
+      this._pendingDismissals = null;
+      if (!next || !this._dismissalsScope) return;
+      this._dismissals = next;
+      saveDismissals(this._dismissalsScope, next);
+    });
   }
 
   private _onDismiss(alert: WeatherAlert): void {
@@ -641,7 +675,11 @@ export class WeatherAlertsCard extends LitElement {
         extreme: 0, severe: 1, moderate: 2, minor: 3, unknown: 4,
       };
       const threshold = severityRank[this._config.minSeverity] ?? 4;
-      result = result.filter(a => (severityRank[a.severity] ?? 4) <= threshold);
+      // 'unknown' means the provider couldn't classify the alert, not that
+      // it's low-priority. Never silently drop it via the severity floor —
+      // suppressing an unclassified weather alert is a safety hazard. Users
+      // who truly want it gone can use eventCode/zone filters instead.
+      result = result.filter(a => a.severity === 'unknown' || (severityRank[a.severity] ?? 4) <= threshold);
     }
 
     if (this._config.hideExpired !== false) {
@@ -1052,8 +1090,7 @@ export class WeatherAlertsCard extends LitElement {
       ` : nothing}
       ${alert.mergedCount && alert.mergedCount > 1
         ? html`<span class="badge zones-badge">${t(
-          alert.mergedCount === 1 ? 'card.zone_count_singular' : 'card.zones_count',
-          this._lang, { count: alert.mergedCount },
+          'card.zones_count', this._lang, { count: alert.mergedCount },
         )}</span>`
         : nothing}
     `;

--- a/src/weather-alerts-card.ts
+++ b/src/weather-alerts-card.ts
@@ -16,7 +16,8 @@ import {
   dismissAlert,
   undoDismiss,
   applyDismissals,
-  computeScopeHash,
+  configuredScopeTokens,
+  scopeHashForConfig,
   subscribeToDismissalChanges,
 } from './dismissal';
 import {
@@ -298,24 +299,13 @@ export class WeatherAlertsCard extends LitElement {
   private get _scopeHash(): string {
     // Hash the *configured* sources (entity + device id), not the resolved
     // entity list — device-mode alerts come and go, and the dismissal scope
-    // must stay stable across that churn.
-    const tokens = this._configuredScopeTokens();
-    if (tokens.length === 0) return '';
-    const [primary, ...extras] = tokens;
-    return computeScopeHash(primary, extras);
+    // must stay stable across that churn. Shared with the editor so both
+    // agree on the storage key (see scopeHashForConfig).
+    return scopeHashForConfig(this._config);
   }
 
   private _configuredScopeTokens(): string[] {
-    if (!this._config) return [];
-    const tokens: string[] = [];
-    if (this._config.entity) tokens.push(this._config.entity);
-    if (this._config.entities) {
-      for (const id of this._config.entities) {
-        if (id) tokens.push(id);
-      }
-    }
-    if (this._config.device) tokens.push(`device:${this._config.device}`);
-    return tokens;
+    return configuredScopeTokens(this._config);
   }
 
   private _reloadDismissalsIfScopeChanged(): void {

--- a/tests/adapters/nws.test.ts
+++ b/tests/adapters/nws.test.ts
@@ -104,6 +104,26 @@ describe('NwsAdapter', () => {
       expect(alerts[0].zones.filter(z => z === 'COZ039')).toHaveLength(1);
     });
 
+    it('skips non-string zone entries without throwing', () => {
+      const attrs = makeNwsAttributes([{
+        // Malformed payload: null / numeric entries mixed with valid ones.
+        AffectedZones: ['https://api.weather.gov/zones/forecast/COZ039', null, 42] as unknown as string[],
+        Geocode: { UGC: ['COC059', null] as unknown as string[] },
+      }]);
+      const alerts = adapter.parseAlerts(attrs);
+      expect(alerts[0].zones).toContain('COZ039');
+      expect(alerts[0].zones).toContain('COC059');
+      expect(alerts[0].zones).toHaveLength(2);
+    });
+
+    it('skips non-object entries in the Alerts array', () => {
+      const valid = makeNwsAttributes([{ Event: 'Tornado Warning' }]);
+      const attrs = { Alerts: [null, 'oops', (valid.Alerts as unknown[])[0]] };
+      const alerts = adapter.parseAlerts(attrs as Record<string, unknown>);
+      expect(alerts).toHaveLength(1);
+      expect(alerts[0].event).toBe('Tornado Warning');
+    });
+
     it('parses timestamps to Unix seconds', () => {
       const attrs = makeNwsAttributes([{
         Sent: '2026-03-06T10:00:00Z',

--- a/tests/card-filter.test.ts
+++ b/tests/card-filter.test.ts
@@ -1,0 +1,106 @@
+import { describe, it, expect, beforeAll, beforeEach } from 'vitest';
+
+// jsdom lacks matchMedia; the card touches it during construction, so the
+// polyfill must be installed before the card module loads.
+beforeAll(() => {
+  if (!window.matchMedia) {
+    Object.defineProperty(window, 'matchMedia', {
+      writable: true,
+      value: () => ({
+        matches: false,
+        media: '',
+        onchange: null,
+        addEventListener: () => {},
+        removeEventListener: () => {},
+        addListener: () => {},
+        removeListener: () => {},
+        dispatchEvent: () => false,
+      }),
+    });
+  }
+});
+
+import '../src/weather-alerts-card';
+import type { HomeAssistant, WeatherAlertsCardConfig } from '../src/types';
+
+interface CardInternals {
+  setConfig(config: WeatherAlertsCardConfig): void;
+  hass: HomeAssistant;
+  remove(): void;
+}
+
+function nwsAlert(event: string, severity: string): Record<string, unknown> {
+  const now = Date.now();
+  return {
+    ID: `${event}-${severity}`,
+    Event: event,
+    Severity: severity,
+    Sent: new Date(now - 2 * 3600 * 1000).toISOString(),
+    Onset: new Date(now - 1 * 3600 * 1000).toISOString(),
+    Ends: new Date(now + 3 * 3600 * 1000).toISOString(),
+    Expires: new Date(now + 3 * 3600 * 1000).toISOString(),
+    Description: 'd',
+    Instruction: '',
+    URL: '',
+    Headline: '',
+  };
+}
+
+function makeHass(alerts: Record<string, unknown>[]): HomeAssistant {
+  return {
+    states: { 'sensor.nws_alerts': { state: String(alerts.length), attributes: { Alerts: alerts } } },
+    locale: { language: 'en' },
+  } as unknown as HomeAssistant;
+}
+
+async function mountCard(config: WeatherAlertsCardConfig, hass: HomeAssistant): Promise<{ card: CardInternals; cleanup: () => void }> {
+  const card = document.createElement('weather-alerts-card') as unknown as CardInternals;
+  card.setConfig(config);
+  card.hass = hass;
+  document.body.appendChild(card);
+  await (card as unknown as { updateComplete: Promise<void> }).updateComplete;
+  return { card, cleanup: () => card.remove() };
+}
+
+function alertTitles(card: CardInternals): string[] {
+  const root = (card as unknown as { shadowRoot: ShadowRoot | null }).shadowRoot;
+  if (!root) throw new Error('no shadowRoot');
+  return [...root.querySelectorAll('.alert-title')].map(el => (el.textContent || '').trim());
+}
+
+beforeEach(() => {
+  const store = new Map<string, string>();
+  Object.defineProperty(globalThis, 'localStorage', {
+    value: {
+      get length() { return store.size; },
+      clear: () => store.clear(),
+      getItem: (k: string) => (store.has(k) ? store.get(k)! : null),
+      setItem: (k: string, v: string) => { store.set(k, String(v)); },
+      removeItem: (k: string) => { store.delete(k); },
+      key: (i: number) => Array.from(store.keys())[i] ?? null,
+    },
+    configurable: true,
+    writable: true,
+  });
+});
+
+describe('minSeverity filter', () => {
+  it('keeps unknown-severity alerts but drops below-threshold classified ones', async () => {
+    const hass = makeHass([
+      nwsAlert('Mystery Alert', ''),            // → severity 'unknown'
+      nwsAlert('Small Craft Advisory', 'Minor'), // → 'minor'
+      nwsAlert('Tornado Warning', 'Extreme'),    // → 'extreme'
+    ]);
+    const { card, cleanup } = await mountCard(
+      { type: 'custom:weather-alerts-card', entity: 'sensor.nws_alerts', minSeverity: 'severe' } as WeatherAlertsCardConfig,
+      hass,
+    );
+    const titles = alertTitles(card);
+    // 'extreme' passes the floor; 'unknown' is never silently dropped; 'minor'
+    // is below 'severe' and is filtered.
+    expect(titles).toContain('Tornado Warning');
+    expect(titles).toContain('Mystery Alert');
+    expect(titles).not.toContain('Small Craft Advisory');
+    cleanup();
+  });
+});

--- a/tests/dismissal.test.ts
+++ b/tests/dismissal.test.ts
@@ -263,6 +263,39 @@ describe('subscribeToDismissalChanges', () => {
     restoreAll('scope');
     expect(hits).toBe(0);
   });
+
+  it('fires on a cross-tab storage event for the matching key', () => {
+    let hits = 0;
+    const unsub = subscribeToDismissalChanges('scope', () => { hits++; });
+    window.dispatchEvent(new StorageEvent('storage', { key: storageKey('scope'), newValue: '{}' }));
+    expect(hits).toBe(1);
+    unsub();
+  });
+
+  it('fires on a cross-tab storage clear (null key)', () => {
+    let hits = 0;
+    const unsub = subscribeToDismissalChanges('scope', () => { hits++; });
+    window.dispatchEvent(new StorageEvent('storage', { key: null }));
+    expect(hits).toBe(1);
+    unsub();
+  });
+
+  it('ignores storage events for unrelated keys', () => {
+    let hits = 0;
+    const unsub = subscribeToDismissalChanges('scope', () => { hits++; });
+    window.dispatchEvent(new StorageEvent('storage', { key: storageKey('other'), newValue: '{}' }));
+    window.dispatchEvent(new StorageEvent('storage', { key: 'some-unrelated-key' }));
+    expect(hits).toBe(0);
+    unsub();
+  });
+
+  it('removes the storage listener on unsubscribe', () => {
+    let hits = 0;
+    const unsub = subscribeToDismissalChanges('scope', () => { hits++; });
+    unsub();
+    window.dispatchEvent(new StorageEvent('storage', { key: storageKey('scope'), newValue: '{}' }));
+    expect(hits).toBe(0);
+  });
 });
 
 describe('applyDismissals', () => {

--- a/tests/dismissal.test.ts
+++ b/tests/dismissal.test.ts
@@ -4,6 +4,8 @@ import {
   STALE_TTL_SEC,
   computeAlertSignature,
   computeScopeHash,
+  configuredScopeTokens,
+  scopeHashForConfig,
   storageKey,
   loadDismissals,
   saveDismissals,
@@ -123,6 +125,51 @@ describe('computeScopeHash', () => {
 describe('storageKey', () => {
   it('prefixes with the v1 namespace', () => {
     expect(storageKey('abc')).toBe(`${STORAGE_KEY_PREFIX}abc`);
+  });
+});
+
+describe('configuredScopeTokens', () => {
+  it('includes the device token (prefixed) for device-mode cards', () => {
+    expect(configuredScopeTokens({ device: 'abc' })).toEqual(['device:abc']);
+  });
+
+  it('combines entity, entities, and device', () => {
+    expect(configuredScopeTokens({
+      entity: 'sensor.a',
+      entities: ['sensor.b'],
+      device: 'dev1',
+    })).toEqual(['sensor.a', 'sensor.b', 'device:dev1']);
+  });
+
+  it('returns [] for empty/undefined config', () => {
+    expect(configuredScopeTokens(undefined)).toEqual([]);
+    expect(configuredScopeTokens({})).toEqual([]);
+  });
+});
+
+describe('scopeHashForConfig', () => {
+  it('produces a non-empty scope for a device-only (CAP) card', () => {
+    // Regression: device-mode CAP cards have no `entity`. A tokeniser that
+    // ignored `device` returned '' here, which made the editor's restore-all
+    // UI invisible and the dismissal subscription watch the wrong scope.
+    const hash = scopeHashForConfig({ device: 'abc' });
+    expect(hash).not.toBe('');
+    expect(hash).toBe(computeScopeHash('device:abc', []));
+  });
+
+  it('matches the storage key the card writes for the same device config', () => {
+    const config = { device: 'cap-device-1' };
+    const fresh = Math.floor(Date.now() / 1000);
+    const dismissals = new Map([['alert-A', makeRecord('sig', fresh)]]);
+    // Simulate the card persisting under its own scope...
+    saveDismissals(scopeHashForConfig(config), dismissals);
+    // ...and the editor reading back under the scope it derives.
+    expect(loadDismissals(scopeHashForConfig(config)).size).toBe(1);
+  });
+
+  it('returns "" when no sources are configured', () => {
+    expect(scopeHashForConfig({})).toBe('');
+    expect(scopeHashForConfig(undefined)).toBe('');
   });
 });
 

--- a/tests/editor-visibility.test.ts
+++ b/tests/editor-visibility.test.ts
@@ -1,10 +1,12 @@
-import { describe, it, expect } from 'vitest';
+import { describe, it, expect, beforeEach } from 'vitest';
 import { WeatherAlertsCardEditor } from '../src/weather-alerts-card-editor';
 import type { WeatherAlertsCardConfig } from '../src/types';
+import { saveDismissals, scopeHashForConfig } from '../src/dismissal';
 
 // Reach into private helpers — this suite exists to pin down the
 // condition-matching heuristics used to sync HA visibility conditions.
 type EditorInternals = {
+  _config: WeatherAlertsCardConfig;
   _syncMultiEntityVisibility(
     config: WeatherAlertsCardConfig,
   ): Record<string, unknown>[] | undefined;
@@ -12,6 +14,8 @@ type EditorInternals = {
     c: Record<string, unknown>,
     managedIds: Set<string>,
   ): boolean;
+  _currentScopeHash(): string;
+  _getDismissedCount(): number;
 };
 
 function makeEditor(): EditorInternals {
@@ -195,5 +199,48 @@ describe('_isManagedCondition', () => {
       { condition: 'or', conditions: [] },
       new Set(),
     )).toBe(false);
+  });
+});
+
+describe('editor dismissal scope (device-mode CAP)', () => {
+  beforeEach(() => {
+    const store = new Map<string, string>();
+    Object.defineProperty(globalThis, 'localStorage', {
+      value: {
+        get length() { return store.size; },
+        clear: () => store.clear(),
+        getItem: (k: string) => (store.has(k) ? store.get(k)! : null),
+        setItem: (k: string, v: string) => { store.set(k, String(v)); },
+        removeItem: (k: string) => { store.delete(k); },
+        key: (i: number) => Array.from(store.keys())[i] ?? null,
+      },
+      configurable: true,
+      writable: true,
+    });
+  });
+
+  it('derives the same scope hash the card uses for a device-only config', () => {
+    const editor = makeEditor();
+    const config = { type: 'custom:weather-alerts-card', device: 'cap-dev-1' } as WeatherAlertsCardConfig;
+    editor._config = config;
+    // The card writes under scopeHashForConfig(config); the editor must read
+    // the identical key, even though there is no `entity`.
+    expect(editor._currentScopeHash()).toBe(scopeHashForConfig(config));
+    expect(editor._currentScopeHash()).not.toBe('');
+  });
+
+  it('counts dismissals stored under the device scope so restore-all is reachable', () => {
+    const config = { type: 'custom:weather-alerts-card', device: 'cap-dev-1' } as WeatherAlertsCardConfig;
+    // Simulate the card having dismissed two alerts under its device scope.
+    // Fresh lastSeenAt so loadDismissals' 30-day staleness prune doesn't drop them.
+    const fresh = Math.floor(Date.now() / 1000);
+    saveDismissals(scopeHashForConfig(config), new Map([
+      ['a', { sig: 's1', dismissedAt: fresh, lastSeenAt: fresh }],
+      ['b', { sig: 's2', dismissedAt: fresh, lastSeenAt: fresh }],
+    ]));
+    const editor = makeEditor();
+    editor._config = config;
+    // Before the fix this was 0 (empty scope) and the restore-all UI never showed.
+    expect(editor._getDismissedCount()).toBe(2);
   });
 });

--- a/tests/localize.test.ts
+++ b/tests/localize.test.ts
@@ -34,6 +34,12 @@ describe('t()', () => {
     expect(t('card.zones_count', 'en', { count: 3 })).toBe('3 zones');
   });
 
+  it('replaces every occurrence of a repeated placeholder', () => {
+    // An unknown key falls through to the raw key verbatim, letting us assert
+    // multi-occurrence substitution without depending on a translation string.
+    expect(t('{x} and {x}', 'en', { x: 'A' })).toBe('A and A');
+  });
+
   it('interpolates named parameters in French', () => {
     expect(t('card.sensor_unavailable', 'fr', { state: 'indisponible' }))
       .toBe("Le capteur d'alerte est indisponible.");

--- a/tests/utils.test.ts
+++ b/tests/utils.test.ts
@@ -663,11 +663,24 @@ describe('deduplicateAlerts', () => {
     const b = makeAlert({ id: 'b', zones: ['COZ040'], areaDesc: 'Zone B' });
     const result = deduplicateAlerts([a, b]);
     expect(result).toHaveLength(1);
-    expect(result[0].id).toBe('a');
+    // Merged alerts get a stable synthetic id derived from the merge key, not
+    // the first member's id (which depends on emission order).
+    expect(result[0].id.startsWith('merged:')).toBe(true);
     expect(result[0].zones).toContain('COZ039');
     expect(result[0].zones).toContain('COZ040');
     expect(result[0].areaDesc).toBe('Zone A; Zone B');
     expect(result[0].mergedCount).toBe(2);
+  });
+
+  it('gives merged alerts an id invariant to member order', () => {
+    // Regression: the representative id must not flip when the upstream
+    // integration reorders zone-split alerts, or browser-local dismissals
+    // (keyed on id) would resurface on every reorder.
+    const a = makeAlert({ id: 'a', zones: ['COZ039'], areaDesc: 'Zone A' });
+    const b = makeAlert({ id: 'b', zones: ['COZ040'], areaDesc: 'Zone B' });
+    const forward = deduplicateAlerts([a, b]);
+    const reversed = deduplicateAlerts([b, a]);
+    expect(forward[0].id).toBe(reversed[0].id);
   });
 
   it('merges three alerts with same key', () => {
@@ -718,8 +731,12 @@ describe('deduplicateAlerts', () => {
     const flood2 = makeAlert({ id: 'f2', event: 'Flood Warning', zones: ['Z2'] });
     const result = deduplicateAlerts([tornado, flood1, flood2]);
     expect(result).toHaveLength(2);
+    // Unmerged single alert keeps its real id; the merged flood group follows
+    // in first-occurrence order with a stable synthetic id.
     expect(result[0].id).toBe('t');
-    expect(result[1].id).toBe('f1');
+    expect(result[1].event).toBe('Flood Warning');
+    expect(result[1].mergedCount).toBe(2);
+    expect(result[1].id.startsWith('merged:')).toBe(true);
   });
 });
 


### PR DESCRIPTION
Resolves issues surfaced by a codebase audit, plus a follow-up fix for the CAP restore-all UI. Each fix ships with regression tests.

## Audit fixes

1. **Registry subscription overhead** — the entity-registry WS subscription is now gated on device mode (card + editor), so a plain `entity`/`entities` card no longer opens a subscription and refetches the full registry on every `entity_registry_updated` event (it never read the result). `subscribeEntityRegistry` also uses a leading-edge throttle so a burst of registry events (integration reload) coalesces into a single trailing refetch instead of one full fetch per entity.

2. **Render purity** — `_getAlerts()` no longer mutates the reactive `_dismissals` state or writes `localStorage` during `render()`; the `lastSeenAt`/un-dismiss reconciliation is deferred to a coalesced microtask. `getCardSize()` (called by HA's layout engine) now runs with `reconcile=false` so layout measurement has no side effects. Dead `_multiProvider` field removed.

3. **`minSeverity` safety** — `unknown`-severity alerts are no longer silently dropped by the severity floor. Suppressing an alert the provider couldn't classify is a hazard in an alerting card; `unknown` always passes the floor.

4. **Dedup id stability** — merged zone-split alerts get a stable id derived from the merge key (`merged:<key>`) instead of `group[0].id`, so browser-local dismissals survive the upstream integration reordering the alert array.

5. **Adapter robustness** — NWS/BoM adapters skip non-object array entries and non-string zone codes, so one malformed element can't throw and blank the whole card.

6. **Cross-tab dismissal sync** — `subscribeToDismissalChanges` also listens for the native `storage` event, so dismissing in one tab updates a dashboard open in another.

7. **Misc** — `t()` now replaces every placeholder occurrence (not just the first); the editor entity-list cache is keyed on config as well as `hass`; removed an unreachable singular zone-count branch.

## Follow-up: restore-all dismissals for device-mode (CAP) cards

The card derived its dismissal scope from entity + entities + **device**, but the editor derived it from entities only. For the recommended CAP setup (`device` configured, no `entity`) the editor computed an **empty** scope, so the dismissed-count / "restore all" status never appeared and the dismissal-change subscription watched the wrong storage key — leaving dismissed CAP alerts unrecoverable from the UI.

Fixed by extracting a single shared scope helper (`configuredScopeTokens` / `scopeHashForConfig` in `dismissal.ts`); the card (`_scopeHash`, `_configuredScopeTokens`) and editor (`_currentScopeHash`) now both delegate to it, so their storage keys can never diverge again.

## Verification

- `npm run lint` (tsc --noEmit): clean
- `npm test`: **517 passing** (regression tests added for every fix)
- `npm run build`: bundle builds successfully

## Notes

- **minSeverity (item 3)**: `unknown` always bypasses the `minSeverity` floor rather than just being re-ranked. If preferred behaviour is for `minSeverity: extreme` to still exclude `unknown`, that's a one-line change.
- **Registry throttle (item 1)**: leading-edge throttle (responsive first fetch, then coalesce) was chosen over a plain trailing debounce to preserve real-world responsiveness and the existing device-mode reactivity tests.

🤖 Generated with [Claude Code](https://claude.com/claude-code)