### PR TITLE
fix(styles): tint preparation icon ring with severity color

### DIFF
--- a/src/styles.ts
+++ b/src/styles.ts
@@ -154,7 +154,7 @@ export const cardStyles = css`
 
   /* Temporal state: preparation — dashed ring */
   .preparation .icon-box {
-    border: 2px dashed var(--divider-color);
+    border: 2px dashed var(--color);
   }
   .icon-box ha-icon { --mdc-icon-size: calc(26px * var(--wac-scale, 1)); }
 


### PR DESCRIPTION
## Summary

The preparation-state icon ring (`.preparation .icon-box`) was drawn with `--divider-color` (neutral grey). That matched the inert `expired` treatment and conflicted with the severity-colored, diagonally-striped progress bar rendered for the same upcoming alert — the icon read as "inert" while the progress bar two lines below read as "upcoming, severity blue."

This switches the dashed ring to `--color` (the alert's severity color), so the ring and the progress fill agree on both axes: same severity hue, same broken texture (dashes echoing the bar's stripes). Grey stays reserved for the genuinely inert `expired` state.

## Before / After

Rendered via `npm run screenshot` (NWS compact, `Snowflake Watch` is the preparation-state alert):

- **Before:** faint grey dashed ring above a bold blue striped progress bar — conflicting cues.
- **After:** bold blue dashed ring matching the blue striped progress bar.

Active alerts (solid ring) and preparation alerts (dashed ring) remain clearly distinguishable at the 44px icon size.

## Notes

- One-line CSS change; no behavior or logic affected.
- Aligns with the project's color regime: shape/weight carries state, color carries severity.
- Screenshots in `img/` intentionally left untouched (updated at release time only).

🤖 Generated with [Claude Code](https://claude.com/claude-code)