### PR TITLE
fix(cap): render alerts from sensors reporting state "unknown"

### DIFF
--- a/src/weather-alerts-card.ts
+++ b/src/weather-alerts-card.ts
@@ -889,9 +889,15 @@ export class WeatherAlertsCard extends LitElement {
       return this._renderPreview();
     }
 
-    // Show unavailable only if all resolved entities are unavailable/unknown
+    // Show unavailable only if every resolved entity is unavailable/unknown
+    // AND carries no parseable alert. CAP per-alert sensors can report state
+    // "unknown" while their attributes hold a fully valid alert (e.g. an NWS
+    // Beach Hazards Statement) — those must still render, not be dropped as a
+    // broken data source.
     const allUnavailable = resolvedEntities.length > 0
-      && resolvedEntities.every(e => e.state === 'unavailable' || e.state === 'unknown');
+      && resolvedEntities.every(e =>
+        (e.state === 'unavailable' || e.state === 'unknown')
+        && getAdapter(this._config!.provider, e.attributes).parseAlerts(e.attributes).length === 0);
     if (allUnavailable) {
       const stateVal = resolvedEntities[0].state;
       return html`

--- a/tests/card-filter.test.ts
+++ b/tests/card-filter.test.ts
@@ -104,3 +104,57 @@ describe('minSeverity filter', () => {
     cleanup();
   });
 });
+
+describe('unavailable banner', () => {
+  // A cap_alerts per-alert sensor can report state "unknown" while its
+  // attributes carry a fully valid alert. It must render the alert, not be
+  // dropped as a broken data source.
+  function capUnknownStateHass(): HomeAssistant {
+    return {
+      states: {
+        'sensor.cap_alerts_beach_hazards': {
+          state: 'unknown',
+          attributes: {
+            incident_platform_version: '1.0',
+            id: 'fefdc9427295',
+            event: 'Beach Hazards Statement',
+            severity: 'Moderate',
+            certainty: 'Likely',
+            urgency: 'Expected',
+            description: 'High wave action and dangerous swimming conditions.',
+            headline: 'Beach Hazards Statement',
+          },
+        },
+      },
+      locale: { language: 'en' },
+    } as unknown as HomeAssistant;
+  }
+
+  it('renders a CAP alert whose sensor sits at state "unknown"', async () => {
+    const { card, cleanup } = await mountCard(
+      { type: 'custom:weather-alerts-card', entity: 'sensor.cap_alerts_beach_hazards' } as WeatherAlertsCardConfig,
+      capUnknownStateHass(),
+    );
+    const root = (card as unknown as { shadowRoot: ShadowRoot | null }).shadowRoot;
+    if (!root) throw new Error('no shadowRoot');
+    expect(alertTitles(card)).toContain('Beach Hazards Statement');
+    // The broken-sensor banner must NOT appear when valid alert data is present.
+    expect(root.querySelector('.sensor-unavailable')).toBeNull();
+    cleanup();
+  });
+
+  it('still shows the broken-sensor banner when an unknown sensor has no alert data', async () => {
+    const hass = {
+      states: { 'sensor.nws_alerts': { state: 'unavailable', attributes: {} } },
+      locale: { language: 'en' },
+    } as unknown as HomeAssistant;
+    const { card, cleanup } = await mountCard(
+      { type: 'custom:weather-alerts-card', entity: 'sensor.nws_alerts' } as WeatherAlertsCardConfig,
+      hass,
+    );
+    const root = (card as unknown as { shadowRoot: ShadowRoot | null }).shadowRoot;
+    if (!root) throw new Error('no shadowRoot');
+    expect(root.querySelector('.sensor-unavailable')).not.toBeNull();
+    cleanup();
+  });
+});


### PR DESCRIPTION
## Summary

A `cap_alerts` per-alert sensor can sit at HA state `unknown` while its attributes carry a **fully valid alert** (e.g. an NWS Beach Hazards Statement: `severity: Moderate`, full description, onset/expiry). The card's render path treated any entity at state `unavailable`/`unknown` as a broken data source and rendered the "Alert sensor is unknown" banner *before* parsing the alert — silently dropping a legitimate alert.

## Fix

In `weather-alerts-card.ts`, only count an `unavailable`/`unknown` entity toward the broken-sensor banner when it **also** yields no parseable alert:

```ts
const allUnavailable = resolvedEntities.length > 0
  && resolvedEntities.every(e =>
    (e.state === 'unavailable' || e.state === 'unknown')
    && getAdapter(this._config!.provider, e.attributes).parseAlerts(e.attributes).length === 0);
```

- A genuinely down sensor (state `unavailable`, empty attributes) still shows the banner.
- An `unknown`-state sensor carrying real alert data now renders the alert.
- The editor preview shows the card rendering itself, so it's fixed by the same change.

## Tests

Added two regression tests in `tests/card-filter.test.ts`:
- CAP alert renders when its sensor sits at state `unknown` (and the banner is absent).
- The broken-sensor banner still appears when an unavailable sensor has no alert data.

Full suite: 545 tests pass; `tsc --noEmit` clean.

## Related

Related to #187 — touches the same `allUnavailable` rendering path (that issue is a separate symptom: hiding the card when unavailable + `hideNoAlerts`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)