### PR TITLE
test: fix flaky device-mode dismissal test via suite-wide teardown

### DIFF
--- a/README.md
+++ b/README.md
@@ -255,7 +255,7 @@ The card auto-detects the provider from entity attributes. Any integration that 
 | DWD | Germany | Built-in [dwd_weather_warnings](https://www.home-assistant.io/integrations/dwd_weather_warnings/) |
 | ECCC | Canada | [seevee/cap_alerts](https://github.com/seevee/cap_alerts) (`provider: eccc`) — the recommended ECCC source; see note below |
 | PirateWeather | Global | [Pirate-Weather/pirate-weather-ha](https://github.com/Pirate-Weather/pirate-weather-ha) |
-| CAP Alerts | Multi-region (NWS, ECCC, MeteoAlarm) | [seevee/cap_alerts](https://github.com/seevee/cap_alerts) — one sensor per active alert; pair with `device:` for auto-discovery |
+| CAP Alerts | Multi-region (NWS, ECCC, MeteoAlarm, WMO) | [seevee/cap_alerts](https://github.com/seevee/cap_alerts) — one sensor per active alert; pair with `device:` for auto-discovery. Ingests any CAP 1.2 feed, including the WMO Severe Weather Information Centre firehose for countries without a dedicated integration |
 
 > **Note on ECCC.** For Environment and Climate Change Canada alerts, use [CAP Alerts](https://github.com/seevee/cap_alerts) (`provider: eccc`). It is the only ECCC source this card recommends — neither the bundled HA core `environment_canada` integration nor the HACS `environment_canada` fork is routed to. See [Canada: ECCC via CAP Alerts](#canada-eccc-via-cap-alerts) below for why.
 

--- a/tests/device-mode.test.ts
+++ b/tests/device-mode.test.ts
@@ -22,6 +22,7 @@ beforeAll(() => {
 });
 
 import { WeatherAlertsCard, resolveDeviceAlertEntities } from '../src/weather-alerts-card';
+import { DISMISSALS_CHANGED_EVENT, storageKey } from '../src/dismissal';
 import type {
   HomeAssistant,
   EntityRegistryDisplayEntry,
@@ -520,5 +521,47 @@ describe('WeatherAlertsCard dismissal scope stability across registry churn', ()
     expect(card._scopeHash).toBe(scopeBefore);
     expect(card._dismissals.size).toBe(1);
     cleanup();
+  });
+
+  it('stops reacting to same-scope dismissal events once disconnected', async () => {
+    // Guards the disconnectedCallback unsubscribe contract. The card subscribes
+    // to a global window event keyed by dismissal scope; if a removed card kept
+    // that listener, it would reload `_dismissals` whenever a later test sharing
+    // the same `device:` scope wrote to storage — the cross-test bleed behind
+    // the intermittent full-suite failure. After disconnect, a scope-matched
+    // notification must NOT mutate the card.
+    const mock = makeMockConnection([entry(ALERT_ID_1)]);
+    const hass = {
+      states: {
+        [ALERT_ID_1]: { state: 'moderate', attributes: capAlertAttrs({ event: 'Frost' }) },
+      },
+      locale: { language: 'en' },
+      entities: undefined,
+      connection: mock.conn,
+    } as unknown as HomeAssistant;
+
+    const { card, cleanup } = await mountCard(
+      {
+        type: 'custom:weather-alerts-card',
+        device: DEVICE,
+        allowDismiss: true,
+      } as WeatherAlertsCardConfig,
+      hass,
+    );
+
+    const scope = card._scopeHash;
+    const alerts = card._getAlerts() as { id: string }[];
+    card._onDismiss(alerts[0]);
+    expect(card._dismissals.size).toBe(1);
+
+    // Disconnect the card — disconnectedCallback must remove the listener.
+    cleanup();
+
+    // Simulate another writer clearing this scope, then broadcasting the change.
+    // A still-subscribed card would reload from the now-empty store (size → 0).
+    localStorage.removeItem(storageKey(scope));
+    window.dispatchEvent(new CustomEvent(DISMISSALS_CHANGED_EVENT, { detail: { scope } }));
+
+    expect(card._dismissals.size).toBe(1);
   });
 });

--- a/tests/setup.ts
+++ b/tests/setup.ts
@@ -1,0 +1,19 @@
+import { afterEach } from 'vitest';
+
+// Suite-wide teardown: force-disconnect every custom element a test mounted.
+//
+// The card subscribes to a *global* `window` event in connectedCallback (the
+// dismissal-change bus) and unsubscribes in disconnectedCallback. Tests share
+// one jsdom `window` across every `it()` in a file, so a card that lingers past
+// a test — a forgotten `cleanup()`, or an async assertion that throws before
+// teardown — keeps a live, scope-matched listener registered. The next test
+// using the same dismissal scope (e.g. the same `device:` id) then sees that
+// stale card reload `_dismissals` from storage at an unpredictable moment.
+//
+// That cross-test bleed only surfaces under full-suite timing, never in
+// isolation — exactly the profile of the intermittent device-mode dismissal
+// failure. Clearing the document between tests triggers disconnectedCallback on
+// every mounted element, tearing down its global listeners deterministically.
+afterEach(() => {
+  document.body.innerHTML = '';
+});

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -6,5 +6,6 @@ export default defineConfig({
   },
   test: {
     environment: 'jsdom',
+    setupFiles: ['./tests/setup.ts'],
   },
 });


### PR DESCRIPTION
## Summary

Fixes the intermittent failure in `tests/device-mode.test.ts` (`_dismissals.size` assertion in the *dismissal scope stability across registry churn* suite) that surfaced only under full-suite timing, never in isolation.

## Root cause

No product bug — it's **cross-test global-state bleed**:

- The card subscribes to a **global `window` event** (the dismissal-change bus) in `connectedCallback` and unsubscribes in `disconnectedCallback`.
- Vitest shares one jsdom `window` across every `it()` in a file, and every test in `device-mode.test.ts` uses the same `device: DEVICE` → **identical dismissal scope hash**.
- A card that lingered past a test (forgotten `cleanup()`, or an async path) kept a live, scope-matched listener. A later test sharing that scope then saw the stale card reload `_dismissals` from storage at an unpredictable moment — load-dependent, hence only visible in the full suite.

## Fix

- **`tests/setup.ts`** (wired via `setupFiles`): a suite-wide `afterEach` that clears the document between tests, triggering `disconnectedCallback` on every mounted element so its global listeners are torn down deterministically. Eliminates the whole class of leaked-listener bleed across all test files.
- **Regression test** in `device-mode.test.ts`: asserts a disconnected card no longer reacts to a same-scope dismissal notification. Verified it **fails** (size → 0, the exact flake signature) when the disconnect-time unsubscribe is removed, and passes with it intact.

## Also

- README: note that the CAP Alerts integration also ingests the **WMO** Severe Weather Information Centre firehose, so it can serve as a WMO source for countries without a dedicated integration.

## Testing

- `tsc --noEmit` clean
- Full suite green across 4 consecutive runs (546 tests, +1 regression test)
- Mutation-checked the regression test against a broken `disconnectedCallback`

🤖 Generated with [Claude Code](https://claude.com/claude-code)