### PR TITLE
docs: add AI-assisted contribution policy (tool, not author)

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -27,3 +27,10 @@ All PRs must pass:
 ## Commit Messages
 
 Use conventional-style prefixes: `feat:`, `fix:`, `chore:`, `docs:`, `refactor:`, `test:`.
+
+## AI-Assisted Contributions
+
+AI coding assistants are welcome as tools, under two rules:
+
+- **You own what you submit.** Review and understand AI-assisted code before opening a PR — you are fully responsible for it, including bugs, security issues, and licensing.
+- **Disclose the tool — as a tool, not an author.** Note the assistant in a commit trailer using the Linux-kernel convention, e.g. `Assisted-by: Claude:claude-fable-5`. Do not credit an AI via `Co-authored-by:`; that trailer is reserved for human co-authors.


### PR DESCRIPTION
## Summary
- Adds an **AI-Assisted Contributions** section to CONTRIBUTING.md
- Contributors using AI assistants take full ownership of what they submit
- AI use is disclosed via the Linux-kernel-style `Assisted-by:` commit trailer; `Co-authored-by:` is reserved for human co-authors

## Context
The ecosystem converged on "tool, not author" attribution in 2026: the [Linux kernel AI coding-assistant policy](https://docs.kernel.org/process/coding-assistants.html) (`Assisted-by:`), the [ASF generative-tooling guidance](https://www.apache.org/legal/generative-tooling.html) (`Generated-by:`), and the VS Code `Co-authored-by: Copilot` rollback. This repo's own commits now follow the kernel convention going forward; existing history is left as-is.

Assisted-by: Claude:claude-fable-5