### PR TITLE
fix(meteoswiss): use warning_links for source link; render open-ended warnings as Ongoing (#186)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## Unreleased
+
+### Fixed
+- Use `warning_links` for the MeteoSwiss source link; render open-ended warnings as "Ongoing" and omit the empty Issued row (#186)
+
 ## 3.2.0-alpha.3 — 2026-07-04
 
 ### Added

--- a/scripts/screenshot-fixtures.js
+++ b/scripts/screenshot-fixtures.js
@@ -331,6 +331,26 @@ export const CAP_GEOMETRY_STUB = {
   ],
 };
 
+// MeteoSwiss aggregate warning with the sparsest possible metadata: the feed
+// publishes no issued time (sentTs stays 0) and this warning is open-ended
+// (warning_valid_to: null → an active, "Ongoing" warning). Exercises the
+// metadata-grid seam that omits the Issued row and renders the End row as
+// "Ongoing" instead of "N/A" (#186). warning_links supplies the working source
+// link. Placeholder content per the card-preview philosophy above.
+export const METEOSWISS_SPARSE_ATTRS = {
+  attribution: 'Source: MeteoSwiss',
+  warning_types: ['Heat wave'],
+  warning_levels: ['Moderate hazard'],
+  warning_levels_numeric: [2],
+  warning_valid_from: [iso(-3 * H)],
+  warning_valid_to: [null],
+  warning_texts: [
+    'A pleasantly warm spell has settled in with no clear end in sight. ' +
+    'Sample data for the card preview — no real action is needed.',
+  ],
+  warning_links: ['https://example.com/meteoswiss/screenshot-sparse'],
+};
+
 // PirateWeather-format duplicates of some NWS alerts (for cross-provider dedup demos).
 // Uses the PirateWeather indexed attribute format (title_0, severity_0, etc.)
 // with matching event names and expiry times so the card's dedup logic merges them.

--- a/scripts/screenshot-harness.html
+++ b/scripts/screenshot-harness.html
@@ -59,9 +59,12 @@
 <body>
 
   <!--
-    Two card instances (Playwright clicks "Read Details" for the details screenshots):
+    Three card instances (Playwright clicks "Read Details" for the details screenshots):
     1. card-severity-open: default layout, severity colors, all alerts collapsed.
     2. card-nws-compact: compact layout, NWS event colors, all alerts collapsed.
+    3. card-meteoswiss-sparse: default layout, a MeteoSwiss open-ended warning with
+       no issued/expiry time — shows the sparse metadata grid (no Issued row, End
+       row reads "Ongoing").
   -->
 
   <div class="card-wrapper">
@@ -70,10 +73,13 @@
   <div class="card-wrapper">
     <weather-alerts-card id="card-nws-compact"></weather-alerts-card>
   </div>
+  <div class="card-wrapper">
+    <weather-alerts-card id="card-meteoswiss-sparse"></weather-alerts-card>
+  </div>
 
   <script type="module">
     import '/dist/weather-alerts-card.js';
-    import { ALERTS } from '/scripts/screenshot-fixtures.js';
+    import { ALERTS, METEOSWISS_SPARSE_ATTRS } from '/scripts/screenshot-fixtures.js';
 
     // ---- ha-card stub ----
     // Shadow DOM with <slot> — matches HA's real <ha-card> structure.
@@ -140,6 +146,10 @@
           state: String(ALERTS.length),
           attributes: { Alerts: ALERTS },
         },
+        'sensor.weather_warnings_at_8000': {
+          state: String(METEOSWISS_SPARSE_ATTRS.warning_types.length),
+          attributes: METEOSWISS_SPARSE_ATTRS,
+        },
       },
     };
 
@@ -154,6 +164,11 @@
     const nwsCompact = document.getElementById('card-nws-compact');
     nwsCompact.setConfig({ type: 'custom:weather-alerts-card', entity: 'sensor.nws_alerts_alerts', animations: false, colorTheme: 'nws', layout: 'compact' });
     nwsCompact.hass = MOCK_HASS;
+
+    // Default layout, MeteoSwiss open-ended warning — the sparse metadata grid.
+    const meteoswissSparse = document.getElementById('card-meteoswiss-sparse');
+    meteoswissSparse.setConfig({ type: 'custom:weather-alerts-card', entity: 'sensor.weather_warnings_at_8000', animations: false, colorTheme: 'severity' });
+    meteoswissSparse.hass = MOCK_HASS;
   </script>
 </body>
 </html>

--- a/scripts/screenshot.js
+++ b/scripts/screenshot.js
@@ -88,6 +88,8 @@ const ALL_SCENARIOS = [
   { cardId: 'card-severity-open', colorScheme: 'dark', label: 'severity dark  details', out: 'img/severity-dark-details.png', expand: true },
   { cardId: 'card-nws-compact', colorScheme: 'light', label: 'nws     light compact ', out: 'img/nws-light-compact.png' },
   { cardId: 'card-nws-compact', colorScheme: 'dark', label: 'nws     dark  compact ', out: 'img/nws-dark-compact.png' },
+  { cardId: 'card-meteoswiss-sparse', colorScheme: 'light', label: 'mswiss  light sparse  ', out: 'img/meteoswiss-light-sparse.png', expand: true },
+  { cardId: 'card-meteoswiss-sparse', colorScheme: 'dark', label: 'mswiss  dark  sparse  ', out: 'img/meteoswiss-dark-sparse.png', expand: true },
 ];
 
 // Filter by SCREENSHOT_THEMES env var if set (e.g. "nws" or "severity,nws")
@@ -136,7 +138,7 @@ const PORT = 3742;
 
     // Wait for both card instances to finish their initial Lit render
     await page.waitForFunction(() => {
-      const ids = ['card-severity-open', 'card-nws-compact'];
+      const ids = ['card-severity-open', 'card-nws-compact', 'card-meteoswiss-sparse'];
       return ids.every(id => document.getElementById(id)?.shadowRoot?.querySelector('.alert-card') !== null);
     }, { timeout: 10000 });
 

--- a/src/adapters/meteoswiss.ts
+++ b/src/adapters/meteoswiss.ts
@@ -4,9 +4,13 @@ import { parseTimestamp } from '../utils';
 // Last-resort fallback when the sensor exposes no per-warning deep link. The
 // integration's own `warning_links` are the primary source (mapped per-alert
 // in parseAlerts); this constant is only reached when that array is empty,
-// which in practice happens only at zero warnings (no alerts emitted).
+// which in practice happens only at zero warnings (no alerts emitted). Points
+// at the interactive severe-weather warnings map (the English-host mirror of
+// meteoschweiz.admin.ch/.../gefahren.html) with the severe-weather tab
+// pre-selected. It is a client-routed SPA, so the base path resolves (200) but
+// only renders in a real browser.
 const METEOSWISS_WARNINGS_URL =
-  'https://www.meteoswiss.admin.ch/home/weather/hazards.html';
+  'https://www.meteoswiss.admin.ch/services-and-publications/applications/hazards.html#tab=severe-weather-map&weather-tab=all';
 
 // Map the integration's numeric WarningLevel (0-5) to the card's severity tier.
 // Mirrors MeteoAlarm's color semantics (the other European provider): red/

--- a/src/adapters/meteoswiss.ts
+++ b/src/adapters/meteoswiss.ts
@@ -1,10 +1,12 @@
 import { AlertAdapter, AlertProvider, AlertSeverity, WeatherAlert } from '../types';
 import { parseTimestamp } from '../utils';
 
-// MeteoSwiss has no per-alert deep link in the aggregate sensor, so we point
-// at the official warnings overview page (same approach as DWD).
+// Last-resort fallback when the sensor exposes no per-warning deep link. The
+// integration's own `warning_links` are the primary source (mapped per-alert
+// in parseAlerts); this constant is only reached when that array is empty,
+// which in practice happens only at zero warnings (no alerts emitted).
 const METEOSWISS_WARNINGS_URL =
-  'https://www.meteoswiss.admin.ch/services-and-publications/service/warnings.html';
+  'https://www.meteoswiss.admin.ch/home/weather/hazards.html';
 
 // Map the integration's numeric WarningLevel (0-5) to the card's severity tier.
 // Mirrors MeteoAlarm's color semantics (the other European provider): red/
@@ -45,6 +47,20 @@ export class MeteoSwissAdapter implements AlertAdapter {
     const validFrom = arr('warning_valid_from');
     const validTo = arr('warning_valid_to');
     const texts = arr('warning_texts');
+    const links = arr('warning_links');
+
+    // `warning_links` is a flat, warning-ordered array carrying a consistent
+    // number of links per warning (observed: 2/warning, lead link = the
+    // type-specific natural-hazards page). Even-divide grouping picks each
+    // warning's lead link for any consistent N:1 ratio; otherwise fall back to
+    // the first real link, then the overview constant.
+    const linkFor = (i: number): string => {
+      if (types.length > 0 && links.length > 0 && links.length % types.length === 0) {
+        return String(links[i * (links.length / types.length)]);
+      }
+      if (links.length > 0) return String(links[0]);
+      return METEOSWISS_WARNINGS_URL;
+    };
 
     const alerts: WeatherAlert[] = [];
 
@@ -72,7 +88,7 @@ export class MeteoSwissAdapter implements AlertAdapter {
         endsTs,
         description: String(texts[i] ?? ''),
         instruction: '',
-        url: METEOSWISS_WARNINGS_URL,
+        url: linkFor(i),
         headline: '',
         areaDesc: '',
         zones: [],

--- a/src/weather-alerts-card.ts
+++ b/src/weather-alerts-card.ts
@@ -1202,10 +1202,12 @@ export class WeatherAlertsCard extends LitElement {
       <div class="details-content">
         ${this._config?.showMetadata !== false ? html`
         <div class="meta-grid">
+          ${progress.sentTs > 100 ? html`
           <div class="meta-item">
             <span class="meta-label">${t('detail.issued', lang)}</span>
             <span class="meta-value">${formatLocalTimestamp(progress.sentTs, this._locale, lang)}</span>
           </div>
+          ` : nothing}
           <div class="meta-item">
             <span class="meta-label">${t('detail.onset', lang)}</span>
             <span class="meta-value">${formatLocalTimestamp(progress.onsetTs, this._locale, lang)}</span>
@@ -1213,10 +1215,10 @@ export class WeatherAlertsCard extends LitElement {
           </div>
           <div class="meta-item">
             <span class="meta-label">${progress.isExpired ? t('progress.expired_label', lang) : t('detail.expires', lang)}</span>
-            <span class="meta-value">${formatLocalTimestamp(progress.endsTs, this._locale, lang)}</span>
             ${progress.hasEndTime
-          ? html`<span class="meta-relative">${formatRelativeTime(progress.endsTs, progress.nowTs, lang)}</span>`
-          : nothing}
+          ? html`<span class="meta-value">${formatLocalTimestamp(progress.endsTs, this._locale, lang)}</span>
+            <span class="meta-relative">${formatRelativeTime(progress.endsTs, progress.nowTs, lang)}</span>`
+          : html`<span class="meta-value">${progress.isActive ? t('progress.ongoing', lang) : t('progress.tbd', lang)}</span>`}
           </div>
           ${alert.areaDesc ? html`
             <div class="meta-item" style="grid-column: 1 / -1;">

--- a/tests/adapters/meteoswiss.test.ts
+++ b/tests/adapters/meteoswiss.test.ts
@@ -34,7 +34,7 @@ function makeMeteoSwissAttributes(
 const DEAD_WARNINGS_URL =
   'https://www.meteoswiss.admin.ch/services-and-publications/service/warnings.html';
 const FALLBACK_WARNINGS_URL =
-  'https://www.meteoswiss.admin.ch/home/weather/hazards.html';
+  'https://www.meteoswiss.admin.ch/services-and-publications/applications/hazards.html#tab=severe-weather-map&weather-tab=all';
 
 describe('MeteoSwissAdapter', () => {
   const adapter = new MeteoSwissAdapter();

--- a/tests/adapters/meteoswiss.test.ts
+++ b/tests/adapters/meteoswiss.test.ts
@@ -14,7 +14,10 @@ function makeMeteoSwissWarning(overrides: Partial<MeteoSwissWarning> = {}): Mete
   };
 }
 
-function makeMeteoSwissAttributes(warnings: Partial<MeteoSwissWarning>[] = [{}]): Record<string, unknown> {
+function makeMeteoSwissAttributes(
+  warnings: Partial<MeteoSwissWarning>[] = [{}],
+  links: string[] = ['https://www.meteoswiss.admin.ch/some/link'],
+): Record<string, unknown> {
   const full = warnings.map(makeMeteoSwissWarning);
   return {
     attribution: 'Source: MeteoSwiss',
@@ -24,9 +27,14 @@ function makeMeteoSwissAttributes(warnings: Partial<MeteoSwissWarning>[] = [{}])
     warning_valid_from: full.map(w => w.validFrom),
     warning_valid_to: full.map(w => w.validTo),
     warning_texts: full.map(w => w.text),
-    warning_links: ['https://www.meteoswiss.admin.ch/some/link'],
+    warning_links: links,
   };
 }
+
+const DEAD_WARNINGS_URL =
+  'https://www.meteoswiss.admin.ch/services-and-publications/service/warnings.html';
+const FALLBACK_WARNINGS_URL =
+  'https://www.meteoswiss.admin.ch/home/weather/hazards.html';
 
 describe('MeteoSwissAdapter', () => {
   const adapter = new MeteoSwissAdapter();
@@ -207,11 +215,51 @@ describe('MeteoSwissAdapter', () => {
       expect(alerts[0].description).toBe(html);
     });
 
-    it('uses the fixed MeteoSwiss warnings page as url', () => {
-      const alerts = adapter.parseAlerts(makeMeteoSwissAttributes([{}]));
-      expect(alerts[0].url).toBe(
-        'https://www.meteoswiss.admin.ch/services-and-publications/service/warnings.html',
-      );
+    it('maps a 1:1 warning_links array to links[i]', () => {
+      const alerts = adapter.parseAlerts(makeMeteoSwissAttributes(
+        [{ type: 'Wind' }, { type: 'Thunderstorms' }],
+        ['https://mch/wind', 'https://mch/thunder'],
+      ));
+      expect(alerts[0].url).toBe('https://mch/wind');
+      expect(alerts[1].url).toBe('https://mch/thunder');
+    });
+
+    it('maps a 2:1 warning_links array to each warning\'s lead link', () => {
+      const alerts = adapter.parseAlerts(makeMeteoSwissAttributes(
+        [{ type: 'Forest fire' }, { type: 'Heat wave' }],
+        [
+          'https://mch/forest-fire',
+          'https://mch/forest-fire/detail',
+          'https://mch/heat-wave',
+          'https://mch/heat-wave/detail',
+        ],
+      ));
+      expect(alerts[0].url).toBe('https://mch/forest-fire');
+      expect(alerts[1].url).toBe('https://mch/heat-wave');
+    });
+
+    it('falls back to links[0] when the count is not evenly divisible', () => {
+      const alerts = adapter.parseAlerts(makeMeteoSwissAttributes(
+        [{ type: 'Wind' }, { type: 'Thunderstorms' }],
+        ['https://mch/first', 'https://mch/second', 'https://mch/third'],
+      ));
+      expect(alerts[0].url).toBe('https://mch/first');
+      expect(alerts[1].url).toBe('https://mch/first');
+    });
+
+    it('falls back to the overview constant when warning_links is empty', () => {
+      const alerts = adapter.parseAlerts(makeMeteoSwissAttributes([{}], []));
+      expect(alerts[0].url).toBe(FALLBACK_WARNINGS_URL);
+    });
+
+    it('never emits the dead service/warnings url when links are present', () => {
+      const alerts = adapter.parseAlerts(makeMeteoSwissAttributes(
+        [{ type: 'Wind' }, { type: 'Thunderstorms' }],
+        ['https://mch/a', 'https://mch/b'],
+      ));
+      for (const a of alerts) {
+        expect(a.url).not.toBe(DEAD_WARNINGS_URL);
+      }
     });
 
     it('returns empty array for empty arrays', () => {

--- a/tests/card-details.test.ts
+++ b/tests/card-details.test.ts
@@ -1,0 +1,176 @@
+import { describe, it, expect, beforeAll, beforeEach } from 'vitest';
+
+// jsdom lacks matchMedia; the card touches it during construction, so the
+// polyfill must be installed before the card module loads.
+beforeAll(() => {
+  if (!window.matchMedia) {
+    Object.defineProperty(window, 'matchMedia', {
+      writable: true,
+      value: () => ({
+        matches: false,
+        media: '',
+        onchange: null,
+        addEventListener: () => {},
+        removeEventListener: () => {},
+        addListener: () => {},
+        removeListener: () => {},
+        dispatchEvent: () => false,
+      }),
+    });
+  }
+});
+
+import '../src/weather-alerts-card';
+import type { HomeAssistant, WeatherAlertsCardConfig } from '../src/types';
+
+interface CardInternals {
+  setConfig(config: WeatherAlertsCardConfig): void;
+  hass: HomeAssistant;
+  remove(): void;
+}
+
+const HOUR = 3600 * 1000;
+
+// A MeteoSwiss aggregate warning sensor. sentTs is always absent (no issued
+// time in the feed); validTo:null models an open-ended ("Ongoing") warning.
+function meteoSwissHass(validFrom: string, validTo: string | null): HomeAssistant {
+  return {
+    states: {
+      'sensor.weather_warnings': {
+        state: '1',
+        attributes: {
+          attribution: 'Source: MeteoSwiss',
+          warning_types: ['Forest fire'],
+          warning_levels: ['Significant hazard'],
+          warning_levels_numeric: [3],
+          warning_valid_from: [validFrom],
+          warning_valid_to: [validTo],
+          warning_texts: ['Elevated forest-fire danger.'],
+          warning_links: ['https://www.meteoswiss.admin.ch/forest-fire'],
+        },
+      },
+    },
+    locale: { language: 'en' },
+  } as unknown as HomeAssistant;
+}
+
+// An NWS alert carries full timing (Sent/Onset/Ends) — the seam's untouched path.
+function nwsFullTimingHass(): HomeAssistant {
+  const now = Date.now();
+  return {
+    states: {
+      'sensor.nws_alerts': {
+        state: '1',
+        attributes: {
+          Alerts: [{
+            ID: 'wind-severe',
+            Event: 'High Wind Warning',
+            Severity: 'Severe',
+            Sent: new Date(now - 2 * HOUR).toISOString(),
+            Onset: new Date(now - 1 * HOUR).toISOString(),
+            Ends: new Date(now + 3 * HOUR).toISOString(),
+            Expires: new Date(now + 3 * HOUR).toISOString(),
+            Description: 'Damaging winds.',
+            Instruction: '',
+            URL: '',
+            Headline: '',
+          }],
+        },
+      },
+    },
+    locale: { language: 'en' },
+  } as unknown as HomeAssistant;
+}
+
+async function mountCard(config: WeatherAlertsCardConfig, hass: HomeAssistant): Promise<{ card: CardInternals; cleanup: () => void }> {
+  const card = document.createElement('weather-alerts-card') as unknown as CardInternals;
+  card.setConfig(config);
+  card.hass = hass;
+  document.body.appendChild(card);
+  await (card as unknown as { updateComplete: Promise<void> }).updateComplete;
+  return { card, cleanup: () => card.remove() };
+}
+
+// Map each meta-grid item's label → value text for deterministic assertions.
+function metaGrid(card: CardInternals): Record<string, string> {
+  const root = (card as unknown as { shadowRoot: ShadowRoot | null }).shadowRoot;
+  if (!root) throw new Error('no shadowRoot');
+  const out: Record<string, string> = {};
+  for (const item of root.querySelectorAll('.meta-item')) {
+    const label = (item.querySelector('.meta-label')?.textContent || '').trim();
+    const value = (item.querySelector('.meta-value')?.textContent || '').trim();
+    out[label] = value;
+  }
+  return out;
+}
+
+beforeEach(() => {
+  const store = new Map<string, string>();
+  Object.defineProperty(globalThis, 'localStorage', {
+    value: {
+      get length() { return store.size; },
+      clear: () => store.clear(),
+      getItem: (k: string) => (store.has(k) ? store.get(k)! : null),
+      setItem: (k: string, v: string) => { store.set(k, String(v)); },
+      removeItem: (k: string) => { store.delete(k); },
+      key: (i: number) => Array.from(store.keys())[i] ?? null,
+    },
+    configurable: true,
+    writable: true,
+  });
+});
+
+describe('metadata-grid seam', () => {
+  const baseConfig = (entity: string): WeatherAlertsCardConfig => ({
+    type: 'custom:weather-alerts-card',
+    entity,
+    expandDetails: true,
+  } as WeatherAlertsCardConfig);
+
+  it('omits the Issued row when there is no issued time', async () => {
+    const from = new Date(Date.now() - HOUR).toISOString();
+    const { card, cleanup } = await mountCard(
+      baseConfig('sensor.weather_warnings'),
+      meteoSwissHass(from, null),
+    );
+    const grid = metaGrid(card);
+    expect(grid).not.toHaveProperty('Issued');
+    expect(grid).toHaveProperty('Onset');
+    cleanup();
+  });
+
+  it('renders an active open-ended warning as "Ongoing", not N/A', async () => {
+    const from = new Date(Date.now() - HOUR).toISOString();
+    const { card, cleanup } = await mountCard(
+      baseConfig('sensor.weather_warnings'),
+      meteoSwissHass(from, null),
+    );
+    expect(metaGrid(card)['Expires']).toBe('Ongoing');
+    cleanup();
+  });
+
+  it('renders an upcoming open-ended warning as "TBD"', async () => {
+    const from = new Date(Date.now() + HOUR).toISOString();
+    const { card, cleanup } = await mountCard(
+      baseConfig('sensor.weather_warnings'),
+      meteoSwissHass(from, null),
+    );
+    expect(metaGrid(card)['Expires']).toBe('TBD');
+    cleanup();
+  });
+
+  it('renders both Issued and Expires rows with timestamps for full-timing alerts', async () => {
+    const { card, cleanup } = await mountCard(
+      baseConfig('sensor.nws_alerts'),
+      nwsFullTimingHass(),
+    );
+    const grid = metaGrid(card);
+    expect(grid).toHaveProperty('Issued');
+    expect(grid['Issued']).not.toBe('');
+    // The End row carries a real timestamp, not the open-ended placeholders.
+    expect(grid['Expires']).not.toBe('Ongoing');
+    expect(grid['Expires']).not.toBe('TBD');
+    expect(grid['Expires']).not.toBe('');
+    cleanup();
+  });
+});


### PR DESCRIPTION
Closes #186. Carves a reusable open-ended-alert rendering seam later consumed by NSW RFS (#178).

## What & why

Reporter posted two real `weather_warnings` state dumps that exposed two defects and one structural insight.

### Adapter — `src/adapters/meteoswiss.ts`
- **Working source link.** Each alert's `url` is now sourced from the integration's own `warning_links` (real deep links) via an even-divide grouping rule (`links[i * (links.length / types.length)]`), falling back to `links[0]`, then a constant. Previously every alert got a hardcoded overview URL.
- **Dead fallback replaced.** The old `METEOSWISS_WARNINGS_URL` (`.../service/warnings.html`) 404s; replaced with `.../home/weather/hazards.html` as a last-resort fallback only (feed links are primary; the constant is effectively unreachable since empty `warning_links` only occurs at zero warnings).

### Card seam — `src/weather-alerts-card.ts` (`_renderDetailsContent`)
- **No more "Issued: N/A".** The Issued metadata row is omitted when there is no issued time (`sentTs <= 100`). MeteoSwiss publishes none.
- **"Ongoing" instead of "N/A".** For open-ended alerts (`!hasEndTime`), the End row renders `Ongoing` when active or `TBD` when upcoming, reusing existing `progress.ongoing`/`progress.tbd` keys (no new i18n).
- Gated purely on `AlertProgress`, so it is **provider-agnostic** — fires for any alert lacking timing. This is the seam #178 (NSW RFS) reuses.

Full-timing providers (NWS, etc.) hit the identical existing branch and render unchanged.

## Sparse metadata grid

Rendered from the new fixture (verified locally, image not committed — screenshots are regenerated at release per project convention):

- Issued row absent · Onset shows "3h ago" · **Expires: Ongoing** · progress bar End: TBD · working "Open MeteoSwiss Source" link.

## Tests
- `tests/adapters/meteoswiss.test.ts` — link-mapping matrix (1:1, 2:1, non-divisible→`links[0]`, empty→constant) + guard that the dead URL never appears.
- `tests/card-details.test.ts` (new) — DOM render assertions: Issued omitted, End = "Ongoing" (active) / "TBD" (upcoming), and both rows present with timestamps for full-timing alerts.
- Full suite green (595 tests); `tsc --noEmit` clean.

## Notes
- No config or public-interface changes; `WeatherAlert.url` stays a single string.
- Screenshot **fixture + harness/scenario wiring** added (`METEOSWISS_SPARSE_ATTRS`, `card-meteoswiss-sparse`); per project convention the actual `img/` PNGs are generated at release, not on this branch.
- The fallback URL is a client-routed SPA that 404s to non-browsers — worth a quick real-browser confirmation before merge.

Assisted-by: Claude:claude-opus-4-8