### PR TITLE
feat: configurable tap_action per alert row (replaces inline-expand)

### DIFF
--- a/README.md
+++ b/README.md
@@ -104,6 +104,39 @@ Deeper layout tweaks (row height, icon chip size) still require reaching into th
 card's internal class names, which are **not** a stable public API and may change
 between releases. Prefer the tokens above where they suffice.
 
+**Bubble Card pop-up** — make a compact chip that opens a
+[Bubble Card](https://github.com/Clooos/Bubble-Card) pop-up instead of expanding
+inline. `tap_action` navigates to the pop-up's hash; the second card *is* the
+pop-up (Bubble listens for that hash and opens). Pair with `hideNoAlerts` so the
+chip vanishes when there's nothing to show.
+
+```yaml
+# 1) The chip: whole row taps through to the pop-up
+type: custom:weather-alerts-card
+entity: sensor.nws_alerts_alerts
+provider: nws
+layout: compact
+hideNoAlerts: true
+tap_action:
+  action: navigate
+  navigation_path: '#weather-alerts'
+
+# 2) The pop-up: a full-detail card behind the hash
+type: custom:bubble-card
+card_type: pop-up
+hash: '#weather-alerts'
+card:
+  type: custom:weather-alerts-card
+  entity: sensor.nws_alerts_alerts
+  provider: nws
+  expandDetails: true
+```
+
+To open a `browser_mod`-style pop-up instead, use
+`tap_action: { action: fire-dom-event, browser_mod: { ... } }` — the card fires
+the standard `ll-custom` event `browser_mod` listens for. For an alert row that
+opens the sensor's more-info dialog, use `tap_action: { action: more-info }`.
+
 </details>
 
 ## Quick Start
@@ -173,6 +206,7 @@ Then click the Download button, and click Reload when prompted.
 | `dismissTrigger` | `'button'` | `'button'`, `'swipe'`, or `'both'` — how an alert is dismissed (swipe covers touch + mouse drag). Requires `allowDismiss` |
 | `dismissButtonStyle` | `'icon'` | `'icon'` or `'labeled'` (icon + "Dismiss" text). No effect when `dismissTrigger: 'swipe'`; compact layout is always icon-only |
 | `showDismissUndo` | `true` | Show an Undo toast when an alert is dismissed. No effect when `allowDismiss` is off |
+| `tap_action` | — | Standard Home Assistant action fired when an alert row is tapped. **When set, the inline expand affordance is replaced** — the whole row becomes the tap target and the compact chevron / "Read Details" toggle is removed (in the default layout, `expandDetails: true` still renders the always-on detail panel below the row). Supported actions: `more-info`, `navigate`, `url`, `toggle`, `call-service` (alias `perform-action`), `fire-dom-event`, `none` (`assist` is intentionally unsupported — it has no meaning on an alert row; `none` is an inert chip: the toggle is removed but tapping does nothing). For `more-info`/`toggle`, the default entity is resolved **per tapped alert** — `tap_action.entity` (explicit) → the alert's own source sensor → `entity` — so per-alert providers (CAP Alerts, NSW RFS) open *that* alert's sensor while aggregate providers (NWS, DWD, …) fall back to the aggregate sensor. `toggle` uses the generic `homeassistant.toggle` service. Absent = today's inline expand/toggle behavior, unchanged. |
 
 <details>
 <summary><strong>Examples</strong></summary>

--- a/README.md
+++ b/README.md
@@ -104,14 +104,26 @@ Deeper layout tweaks (row height, icon chip size) still require reaching into th
 card's internal class names, which are **not** a stable public API and may change
 between releases. Prefer the tokens above where they suffice.
 
-**Bubble Card pop-up** — make a compact chip that opens a
+**Bubble Card pop-up** — send the compact layout's rows to a
 [Bubble Card](https://github.com/Clooos/Bubble-Card) pop-up instead of expanding
 inline. `tap_action` navigates to the pop-up's hash; the second card *is* the
 pop-up (Bubble listens for that hash and opens). Pair with `hideNoAlerts` so the
-chip vanishes when there's nothing to show.
+entry rows vanish when there's nothing to show.
+
+Two things to know before wiring this up:
+
+- **The pop-up is shared, not per-alert.** A Bubble hash addresses one static
+  pop-up, so every row navigates to the same one and it shows *all* current
+  alerts in full detail — not only the alert you tapped. Per-alert scoping can't
+  be expressed with a hash. To open the tapped alert's own sensor instead, use
+  `tap_action: { action: more-info }`, which opens Home Assistant's native dialog
+  for it.
+- **`layout: compact` renders one row per alert**, not a single summary chip.
+  With three active alerts you get three entry rows, all tapping through to the
+  same pop-up.
 
 ```yaml
-# 1) The chip: whole row taps through to the pop-up
+# 1) The entry rows: each row taps through to the shared pop-up
 type: custom:weather-alerts-card
 entity: sensor.nws_alerts_alerts
 provider: nws
@@ -121,7 +133,7 @@ tap_action:
   action: navigate
   navigation_path: '#weather-alerts'
 
-# 2) The pop-up: a full-detail card behind the hash
+# 2) The pop-up: one full-detail card behind the hash, listing every current alert
 type: custom:bubble-card
 card_type: pop-up
 hash: '#weather-alerts'
@@ -134,8 +146,7 @@ card:
 
 To open a `browser_mod`-style pop-up instead, use
 `tap_action: { action: fire-dom-event, browser_mod: { ... } }` — the card fires
-the standard `ll-custom` event `browser_mod` listens for. For an alert row that
-opens the sensor's more-info dialog, use `tap_action: { action: more-info }`.
+the standard `ll-custom` event `browser_mod` listens for.
 
 </details>
 

--- a/scripts/encode-adaptive-svgs.sh
+++ b/scripts/encode-adaptive-svgs.sh
@@ -15,6 +15,7 @@ PAIRS=(
   "geometry-light.png geometry-dark.png geometry-adaptive.svg"
   "unavailable-light.png unavailable-dark.png unavailable-adaptive.svg"
   "surface-theming-light.png surface-theming-dark.png surface-theming-adaptive.svg"
+  "tap-action-light.png tap-action-dark.png tap-action-adaptive.svg"
 )
 
 for pair in "${PAIRS[@]}"; do

--- a/scripts/screenshot-tap-action.html
+++ b/scripts/screenshot-tap-action.html
@@ -1,0 +1,486 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Weather Alerts Card – tap_action → Bubble Card pop-up</title>
+  <style>
+    /* ---- HA theme variables, toggled via .theme-light / .theme-dark on the canvas ----
+       This harness renders the README's Bubble Card pop-up recipe as a single
+       scene: a dashboard with a compact, whole-row-tappable alert chip, dimmed
+       under a scrim, with a Bubble Card pop-up sheet risen over the bottom.
+
+         1. The chip  — layout: compact + tap_action: navigate → #weather-alerts,
+            hideNoAlerts. The whole row is the tap target; the inline chevron is
+            gone (tap_action replaces inline-expand).
+         2. The pop-up — a full-detail weather-alerts-card (expandDetails: true)
+            behind the hash. Bubble Card supplies the pop-up chrome; it is an
+            external card (not a dep here), so the sheet/grabber/scrim are mocked.
+
+       Deep integration is on the *card* side, not Bubble's: inside the sheet the
+       card is driven transparent + borderless via the #215 --wac-* surface
+       tokens (--wac-card-background / --wac-alert-border / --ha-card-box-shadow),
+       so it dissolves into the sheet instead of stacking a second bordered box.
+       The alert's severity — the red the card would otherwise paint as a full
+       perimeter border — is *promoted* to the sheet chrome (top accent + title
+       icon). The Bubble chrome itself is kept deliberately generic so the figure
+       doesn't imply one specific Bubble skin. */
+    .theme-light {
+      --primary-text-color: #1a1c22;
+      --secondary-text-color: #4a4e59;
+      --primary-background-color: #f2f4f8;
+      --secondary-background-color: rgba(0, 0, 0, 0.08);
+      --card-background-color: #ffffff;
+      --divider-color: rgba(0, 0, 0, 0.14);
+      --error-color: #db4437;
+      --warning-color: #ffa600;
+      --info-color: #4f86f7;
+      --text-primary-color: #ffffff;
+      --rgb-primary-text-color: 26, 28, 34;
+      --ha-card-box-shadow:
+        0px 2px 1px -1px rgba(0, 0, 0, 0.2),
+        0px 1px 1px 0px rgba(0, 0, 0, 0.14),
+        0px 1px 3px 0px rgba(0, 0, 0, 0.12);
+      /* dashboard backdrop + Bubble sheet surfaces */
+      --stage-bg:
+        radial-gradient(circle at 18% 6%, #e2e9f6 0%, transparent 46%),
+        radial-gradient(circle at 90% 4%, #e9eef8 0%, transparent 42%),
+        #eef1f6;
+      --dummy-tile: #ffffff;
+      --dummy-line: rgba(0, 0, 0, 0.09);
+      --sheet-bg: #f6f8fb;
+      --sheet-grabber: rgba(0, 0, 0, 0.20);
+      --sheet-hairline: rgba(0, 0, 0, 0.10);
+      --scrim: rgba(18, 22, 31, 0.42);
+      --stage-title: rgba(0, 0, 0, 0.74);
+      --stage-caption: rgba(0, 0, 0, 0.52);
+      --pill-bg: rgba(255, 255, 255, 0.92);
+      --pill-fg: rgba(0, 0, 0, 0.68);
+      --pill-shadow: 0 2px 8px rgba(0, 0, 0, 0.18);
+      --flow-color: #4f86f7;
+      --sev: var(--error-color);
+    }
+    .theme-dark {
+      --primary-text-color: #f2f4f8;
+      --secondary-text-color: #b8c0cc;
+      --primary-background-color: #0b0e14;
+      --secondary-background-color: rgba(255, 255, 255, 0.10);
+      --card-background-color: #1c1c1e;
+      --divider-color: rgba(255, 255, 255, 0.16);
+      --error-color: #cf6679;
+      --warning-color: #e68900;
+      --info-color: #6aa8ff;
+      --text-primary-color: #ffffff;
+      --rgb-primary-text-color: 242, 244, 248;
+      --ha-card-box-shadow: 0px 8px 24px rgba(0, 0, 0, 0.35);
+      --stage-bg:
+        radial-gradient(circle at 18% 6%, #17222f 0%, transparent 46%),
+        radial-gradient(circle at 90% 4%, #131c28 0%, transparent 42%),
+        #0b0e14;
+      --dummy-tile: #17181c;
+      --dummy-line: rgba(255, 255, 255, 0.10);
+      --sheet-bg: #17181d;
+      --sheet-grabber: rgba(255, 255, 255, 0.26);
+      --sheet-hairline: rgba(255, 255, 255, 0.12);
+      --scrim: rgba(0, 0, 0, 0.58);
+      --stage-title: rgba(255, 255, 255, 0.92);
+      --stage-caption: rgba(255, 255, 255, 0.6);
+      --pill-bg: rgba(28, 30, 36, 0.94);
+      --pill-fg: rgba(255, 255, 255, 0.8);
+      --pill-shadow: 0 2px 10px rgba(0, 0, 0, 0.5);
+      --flow-color: #6aa8ff;
+      --sev: var(--error-color);
+    }
+
+    * { box-sizing: border-box; margin: 0; padding: 0; }
+
+    body {
+      margin: 0;
+      padding: 0;
+      background: transparent;
+      font-family: Roboto, "Noto Sans", sans-serif;
+    }
+
+    /* ---- The scene: one dashboard viewport, dimmed, with a pop-up over it ---- */
+    .tap-canvas {
+      position: relative;
+      width: 1200px;
+      height: 1010px;
+      overflow: hidden;
+      border-radius: 22px;
+      background: var(--stage-bg);
+    }
+
+    /* ---- The dashboard behind the pop-up: multi-column masonry of dummy tiles,
+            with the real chip placed in the top-centre so it clears the sheet. */
+    .dashboard {
+      position: absolute;
+      inset: 0;
+      padding: 62px 40px 30px;
+      display: grid;
+      grid-template-columns: repeat(3, 1fr);
+      grid-auto-rows: min-content;
+      gap: 16px;
+      align-content: start;
+    }
+    .dummy-tile {
+      background: var(--dummy-tile);
+      border-radius: 14px;
+      box-shadow: var(--ha-card-box-shadow);
+      padding: 15px 16px;
+      display: flex;
+      align-items: center;
+      gap: 12px;
+    }
+    .dummy-tile.tall { padding-bottom: 34px; }
+    .dummy-dot {
+      width: 32px; height: 32px; border-radius: 50%;
+      background: var(--dummy-line);
+      flex: 0 0 auto;
+    }
+    .dummy-bars { flex: 1; display: flex; flex-direction: column; gap: 7px; }
+    .dummy-bar { height: 8px; border-radius: 4px; background: var(--dummy-line); }
+    .dummy-bar.short { width: 45%; }
+
+    /* The chip sits in the dashboard flow (top-centre column). A pointer + ripple
+       cue marks the tap; a small config pill names the recipe. */
+    .chip-slot { position: relative; }
+    .chip-slot .card-wrapper { position: relative; z-index: 1; }
+    .tap-ripple {
+      position: absolute;
+      right: 20px; bottom: -10px;
+      width: 48px; height: 48px;
+      border: 2px solid var(--flow-color);
+      border-radius: 50%;
+      opacity: 0.75;
+      z-index: 2;
+      pointer-events: none;
+    }
+    .tap-cursor {
+      position: absolute;
+      right: 28px; bottom: -16px;
+      width: 30px; height: 30px;
+      color: var(--primary-text-color);
+      filter: drop-shadow(0 2px 3px rgba(0,0,0,0.4));
+      z-index: 3;
+      pointer-events: none;
+    }
+    .config-pill {
+      position: absolute;
+      left: 0; top: -30px;
+      display: inline-flex;
+      align-items: center;
+      gap: 6px;
+      background: var(--pill-bg);
+      color: var(--pill-fg);
+      box-shadow: var(--pill-shadow);
+      border-radius: 999px;
+      padding: 5px 12px;
+      font-family: "Roboto Mono", ui-monospace, monospace;
+      font-size: 12px;
+      white-space: nowrap;
+      z-index: 4;
+    }
+    .config-pill .num {
+      font-family: Roboto, sans-serif;
+      font-weight: 700;
+      color: var(--flow-color);
+    }
+
+    /* ---- The scrim: dims the whole dashboard, below the sheet ---- */
+    .scrim {
+      position: absolute;
+      inset: 0;
+      background: var(--scrim);
+      z-index: 5;
+    }
+
+    /* ---- Scene caption (top-left, over the scrim) ---- */
+    .scene-title {
+      position: absolute;
+      left: 40px; top: 26px;
+      z-index: 8;
+      max-width: 340px;
+    }
+    .scene-title h2 {
+      color: #fff;
+      font-size: 20px;
+      font-weight: 700;
+      letter-spacing: 0.2px;
+    }
+
+    /* ---- The Bubble Card pop-up sheet, risen over the bottom of the dashboard.
+            Generic chrome; severity is promoted here from the card. ---- */
+    /* Wrapper handles bottom-anchored centring; the sheet clips its own overflow
+       (rounded corners + spine), so the floating ② pill lives on the wrapper —
+       above the sheet — where the sheet's overflow:hidden can't clip it. */
+    .popup-wrap {
+      position: absolute;
+      bottom: 0; left: 50%;
+      transform: translateX(-50%);
+      width: 680px;
+      max-width: calc(100% - 96px);
+      z-index: 7;
+    }
+    .bubble-sheet {
+      position: relative;
+      width: 100%;
+      background: var(--sheet-bg);
+      border-radius: 28px 28px 0 0;
+      box-shadow: 0 -22px 70px rgba(0, 0, 0, 0.34);
+      padding-bottom: 24px;
+      overflow: hidden;
+    }
+    /* ② config pill, floating above the pop-up header (mirrors the ① chip pill) */
+    .popup-pill {
+      position: absolute;
+      left: 50%; top: -34px;
+      transform: translateX(-50%);
+      z-index: 8;
+    }
+    /* Promoted severity: a single full-height left spine on the pop-up itself.
+       It spans the whole sheet (header + content) and lines up flush with the
+       card's own content-region spine into one continuous status stripe — the
+       recognised "alert stripe" pattern, which reads on any surface without
+       double-framing. No horizontal top accent: the pop-up already has a header,
+       so a second horizontal bar would compete with it. */
+    .bubble-sheet::before {
+      content: "";
+      position: absolute;
+      left: 0; top: 0; bottom: 0;
+      width: 6px;
+      background: var(--sev);
+      z-index: 2;
+    }
+    .bubble-grabber {
+      width: 44px; height: 5px; border-radius: 3px;
+      background: var(--sheet-grabber);
+      margin: 11px auto 6px;
+    }
+    .bubble-header {
+      display: flex;
+      align-items: center;
+      justify-content: space-between;
+      padding: 8px 20px 12px;
+      border-bottom: 1px solid var(--sheet-hairline);
+    }
+    .bubble-title {
+      color: var(--primary-text-color);
+      font-size: 16px; font-weight: 600;
+      display: flex; align-items: center; gap: 10px;
+    }
+    /* title icon carries the promoted severity tint */
+    .bubble-title .b-icon { width: 22px; height: 22px; color: var(--sev); }
+    .bubble-close {
+      width: 32px; height: 32px; border-radius: 50%;
+      background: var(--secondary-background-color);
+      color: var(--secondary-text-color);
+      display: flex; align-items: center; justify-content: center;
+    }
+    .bubble-close svg { width: 16px; height: 16px; }
+
+    /* The card lives in the sheet, driven transparent via --wac-* tokens so it
+       reads as content on the sheet rather than a nested bordered card. Full-bleed
+       (no sheet-card padding) so the card's own severity left-spine sits flush to
+       the pop-up's left edge — no margin — pairing with the promoted top accent to
+       frame the whole pop-up as an extreme alert. The card supplies its own
+       internal padding, so text stays off the edge. */
+    .sheet-card {
+      padding: 4px 0 0;
+    }
+    .sheet-card .card-wrapper {
+      --wac-card-background: transparent;
+      --wac-alert-background: transparent;
+      --wac-alert-border: none;
+      --wac-alert-shadow: none;
+      --ha-card-box-shadow: none;
+    }
+  </style>
+</head>
+<body>
+
+  <div class="tap-canvas" id="tap-action-canvas">
+
+    <!-- ===== Dashboard (dimmed, behind the pop-up) ===== -->
+    <div class="dashboard">
+      <!-- row 1: left tile · chip · right tile -->
+      <div class="dummy-tile">
+        <div class="dummy-dot"></div>
+        <div class="dummy-bars"><div class="dummy-bar"></div><div class="dummy-bar short"></div></div>
+      </div>
+
+      <div class="chip-slot">
+        <div class="config-pill"><span class="num">1</span> tap_action → #weather-alerts</div>
+        <div class="card-wrapper">
+          <weather-alerts-card id="card-tap-chip"></weather-alerts-card>
+        </div>
+        <div class="tap-ripple"></div>
+        <svg class="tap-cursor" viewBox="0 0 24 24" fill="currentColor">
+          <path d="M9 3l10.5 4.5-4.2 1.8 3.3 3.3-1.9 1.9-3.3-3.3-1.8 4.2z"/>
+        </svg>
+      </div>
+
+      <div class="dummy-tile">
+        <div class="dummy-dot"></div>
+        <div class="dummy-bars"><div class="dummy-bar short"></div><div class="dummy-bar"></div></div>
+      </div>
+
+      <!-- row 2 -->
+      <div class="dummy-tile tall">
+        <div class="dummy-dot"></div>
+        <div class="dummy-bars"><div class="dummy-bar"></div><div class="dummy-bar short"></div></div>
+      </div>
+      <div class="dummy-tile">
+        <div class="dummy-dot"></div>
+        <div class="dummy-bars"><div class="dummy-bar short"></div><div class="dummy-bar"></div></div>
+      </div>
+      <div class="dummy-tile tall">
+        <div class="dummy-dot"></div>
+        <div class="dummy-bars"><div class="dummy-bar"></div><div class="dummy-bar short"></div></div>
+      </div>
+
+      <!-- row 3 (mostly behind the sheet) -->
+      <div class="dummy-tile">
+        <div class="dummy-dot"></div>
+        <div class="dummy-bars"><div class="dummy-bar short"></div><div class="dummy-bar"></div></div>
+      </div>
+      <div class="dummy-tile">
+        <div class="dummy-dot"></div>
+        <div class="dummy-bars"><div class="dummy-bar"></div><div class="dummy-bar short"></div></div>
+      </div>
+      <div class="dummy-tile">
+        <div class="dummy-dot"></div>
+        <div class="dummy-bars"><div class="dummy-bar short"></div><div class="dummy-bar"></div></div>
+      </div>
+    </div>
+
+    <!-- ===== Scrim dims the dashboard ===== -->
+    <div class="scrim"></div>
+
+    <!-- ===== Scene caption ===== -->
+    <div class="scene-title">
+      <h2>Tap&nbsp;→ Bubble Card pop-up</h2>
+    </div>
+
+    <!-- ===== The Bubble Card pop-up sheet ===== -->
+    <div class="popup-wrap">
+      <div class="config-pill popup-pill"><span class="num">2</span> custom:bubble-card · pop-up · expandDetails: true</div>
+      <div class="bubble-sheet">
+        <div class="bubble-grabber"></div>
+        <div class="bubble-header">
+          <div class="bubble-title">
+            <svg class="b-icon" viewBox="0 0 24 24" fill="currentColor"><path d="M12 2L1 21h22L12 2zm0 4l7.5 13h-15L12 6zm-1 4v4h2v-4h-2zm0 6v2h2v-2h-2z"/></svg>
+            Weather Alerts
+          </div>
+          <div class="bubble-close">
+            <svg viewBox="0 0 24 24" fill="currentColor"><path d="M19 6.4L17.6 5 12 10.6 6.4 5 5 6.4 10.6 12 5 17.6 6.4 19 12 13.4 17.6 19 19 17.6 13.4 12z"/></svg>
+          </div>
+        </div>
+        <div class="sheet-card">
+          <div class="card-wrapper">
+            <weather-alerts-card id="card-tap-popup"></weather-alerts-card>
+          </div>
+        </div>
+      </div>
+    </div>
+
+  </div>
+
+  <script type="module">
+    import '/dist/weather-alerts-card.js';
+    import { ALERTS } from '/scripts/screenshot-fixtures.js';
+
+    // ---- ha-card stub ----
+    class HaCard extends HTMLElement {
+      set header(v) {}
+      constructor() {
+        super();
+        this.attachShadow({ mode: 'open' });
+        this.shadowRoot.innerHTML = `
+          <style>
+            :host {
+              display: block;
+              background: var(--ha-card-background, var(--card-background-color, white));
+              border-radius: var(--ha-card-border-radius, 12px);
+              box-shadow: var(--ha-card-box-shadow);
+              overflow: hidden;
+            }
+          </style>
+          <slot></slot>
+        `;
+      }
+    }
+    customElements.define('ha-card', HaCard);
+
+    // ---- ha-icon stub ----
+    class HaIcon extends HTMLElement {
+      static get observedAttributes() { return ['icon']; }
+      constructor() {
+        super();
+        this.attachShadow({ mode: 'open' });
+      }
+      connectedCallback() { this._render(); }
+      attributeChangedCallback() { this._render(); }
+
+      _render() {
+        const icon = this.getAttribute('icon') || '';
+        const path = (window.__MDI_ICONS__ || {})[icon];
+        const size = this.style.width || 'var(--mdc-icon-size, 24px)';
+        this.style.display = 'inline-flex';
+        this.style.alignItems = 'center';
+        this.style.justifyContent = 'center';
+        this.shadowRoot.innerHTML = path
+          ? `<svg viewBox="0 0 24 24"
+               style="width:${size};height:${size};display:block;fill:currentColor">
+               <path d="${path}"/>
+             </svg>`
+          : `<svg viewBox="0 0 24 24"
+               style="width:${size};height:${size};display:block;fill:currentColor">
+               <circle cx="12" cy="12" r="9"/>
+             </svg>`;
+      }
+    }
+    customElements.define('ha-icon', HaIcon);
+
+    // ---- Mock hass ----
+    // The chip and the pop-up show the *same* alert (Tornado of Compliments):
+    // the compact row is what you tap, the pop-up is the full detail it opens.
+    const ENTITY = 'sensor.nws_alerts_alerts';
+    const ALERT = [ALERTS[0]];
+    const hassFor = (alerts) => ({
+      locale: { language: 'en', time_format: '12', date_format: 'MDY' },
+      config: { time_zone: 'America/Denver' },
+      states: {
+        [ENTITY]: { state: String(alerts.length), attributes: { Alerts: alerts } },
+      },
+    });
+
+    // ---- 1) The chip: compact + tap_action navigate, hideNoAlerts ----
+    const chip = document.getElementById('card-tap-chip');
+    chip.setConfig({
+      type: 'custom:weather-alerts-card',
+      entity: ENTITY,
+      provider: 'nws',
+      animations: false,
+      colorTheme: 'severity',
+      layout: 'compact',
+      hideNoAlerts: true,
+      tap_action: { action: 'navigate', navigation_path: '#weather-alerts' },
+    });
+    chip.hass = hassFor(ALERT);
+
+    // ---- 2) The pop-up: full layout, expandDetails ----
+    const popup = document.getElementById('card-tap-popup');
+    popup.setConfig({
+      type: 'custom:weather-alerts-card',
+      entity: ENTITY,
+      provider: 'nws',
+      animations: false,
+      colorTheme: 'severity',
+      sortOrder: 'severity',
+      expandDetails: true,
+    });
+    popup.hass = hassFor(ALERT);
+  </script>
+</body>
+</html>

--- a/scripts/screenshot.js
+++ b/scripts/screenshot.js
@@ -289,6 +289,16 @@ const PORT = 3742;
       },
     },
     {
+      name: 'tap-action',
+      url: `http://127.0.0.1:${PORT}/scripts/screenshot-tap-action.html`,
+      canvasId: 'tap-action-canvas',
+      cardIds: ['card-tap-chip', 'card-tap-popup'],
+      variants: [
+        { theme: 'theme-light', label: 'tap    light', out: 'img/tap-action-light.png' },
+        { theme: 'theme-dark',  label: 'tap    dark ', out: 'img/tap-action-dark.png' },
+      ],
+    },
+    {
       name: 'unavailable',
       url: `http://127.0.0.1:${PORT}/scripts/screenshot-unavailable.html`,
       canvasId: 'unavailable-canvas',

--- a/src/actions.ts
+++ b/src/actions.ts
@@ -61,7 +61,7 @@ export function handleTapAction(
     }
     case 'url': {
       if (!action.url_path) return;
-      window.open(action.url_path);
+      window.open(action.url_path, '_blank', 'noopener');
       break;
     }
     case 'toggle': {

--- a/src/actions.ts
+++ b/src/actions.ts
@@ -1,0 +1,97 @@
+// Dependency-free Home-Assistant action dispatcher for the card's `tap_action`.
+//
+// A deliberate hand-roll (no `custom-card-helpers`): that library pulls a large,
+// non-tree-shakeable runtime tree into a bundle we keep lean. The pieces the card
+// actually needs (fire the standard HA DOM events / service calls) are small and
+// implemented here. See plans/tap-action.md, Design Decision D1.
+
+import type { ActionConfig, HomeAssistant } from './types';
+
+// Dispatch a composed, bubbling CustomEvent from `node` — the same shape HA's
+// own frontend uses so browser_mod / Bubble Card / the more-info dialog listen.
+export function fireEvent<T>(
+  node: EventTarget,
+  type: string,
+  detail?: T,
+): void {
+  node.dispatchEvent(
+    new CustomEvent(type, {
+      detail,
+      bubbles: true,
+      composed: true,
+    }),
+  );
+}
+
+// Presence — not truthiness — is the trigger: any `tap_action` (including
+// `{ action: 'none' }`) replaces the inline expand affordance.
+export function hasTapAction(
+  config: { tap_action?: ActionConfig } | undefined | null,
+): boolean {
+  return config?.tap_action !== undefined;
+}
+
+// Translate an ActionConfig into the standard HA DOM events / service calls.
+// `defaultEntity` is the already-resolved per-alert fallback entity (see the
+// card's _onCardAction); the dispatcher only knows `action.entity ?? defaultEntity`.
+export function handleTapAction(
+  node: EventTarget,
+  hass: HomeAssistant | undefined,
+  action: ActionConfig,
+  defaultEntity?: string,
+): void {
+  switch (action.action) {
+    case 'more-info': {
+      const entityId = action.entity ?? defaultEntity;
+      if (!entityId) return;
+      fireEvent(node, 'hass-more-info', { entityId });
+      break;
+    }
+    case 'navigate': {
+      const path = action.navigation_path;
+      if (!path) return;
+      const replace = action.navigation_replace === true;
+      if (replace) {
+        history.replaceState(null, '', path);
+      } else {
+        history.pushState(null, '', path);
+      }
+      fireEvent(window, 'location-changed', { replace });
+      break;
+    }
+    case 'url': {
+      if (!action.url_path) return;
+      window.open(action.url_path);
+      break;
+    }
+    case 'toggle': {
+      const entityId = action.entity ?? defaultEntity;
+      if (!entityId || !hass?.callService) return;
+      hass.callService('homeassistant', 'toggle', { entity_id: entityId });
+      break;
+    }
+    case 'call-service':
+    case 'perform-action': {
+      const service = action.perform_action ?? action.service;
+      if (!service || !hass?.callService) return;
+      const idx = service.indexOf('.');
+      if (idx < 0) return;
+      const domain = service.slice(0, idx);
+      const serviceName = service.slice(idx + 1);
+      hass.callService(
+        domain,
+        serviceName,
+        action.data ?? action.service_data,
+        action.target,
+      );
+      break;
+    }
+    case 'fire-dom-event': {
+      fireEvent(node, 'll-custom', action);
+      break;
+    }
+    // 'none' and any unknown action → no-op.
+    default:
+      break;
+  }
+}

--- a/src/styles.ts
+++ b/src/styles.ts
@@ -194,6 +194,17 @@ export const cardStyles = css`
     margin-bottom: 0;
   }
 
+  /* tap_action: the whole row is a keyboard-operable action target (the inline
+     expand affordance is dropped). Only applied to actionable rows (present AND
+     not action:none); inert rows carry no cursor/role/focus. */
+  .alert-card.tappable {
+    cursor: pointer;
+  }
+  .alert-card.tappable:focus-visible {
+    outline: 2px solid var(--wac-focus-ring, var(--primary-color));
+    outline-offset: 2px;
+  }
+
   .alert-card::before {
     content: "";
     position: absolute;

--- a/src/types.ts
+++ b/src/types.ts
@@ -21,6 +21,39 @@ export interface HomeAssistant {
   devices?: Record<string, DeviceRegistryDisplayEntry>;
   // Live WS connection — used to subscribe to entity_registry updates.
   connection?: Connection;
+  // Fire a HA service call. Present on the real hass object; typed here as the
+  // subset used by tap_action dispatch (toggle / call-service).
+  callService?(
+    domain: string,
+    service: string,
+    data?: Record<string, unknown>,
+    target?: Record<string, unknown>,
+  ): Promise<unknown>;
+}
+
+// Standard Home-Assistant action config accepted by `tap_action`. `assist` is
+// intentionally excluded (it opens the voice-assistant dialog — meaningless on
+// an alert row). The index signature carries arbitrary `fire-dom-event` payloads.
+export interface ActionConfig {
+  action:
+    | 'more-info'
+    | 'navigate'
+    | 'url'
+    | 'toggle'
+    | 'call-service'
+    | 'perform-action'
+    | 'fire-dom-event'
+    | 'none';
+  entity?: string;
+  navigation_path?: string;
+  navigation_replace?: boolean;
+  url_path?: string;
+  service?: string;
+  perform_action?: string;
+  data?: Record<string, unknown>;
+  service_data?: Record<string, unknown>;
+  target?: Record<string, unknown>;
+  [key: string]: unknown;
 }
 
 export interface DeviceRegistryDisplayEntry {
@@ -106,6 +139,7 @@ export interface WeatherAlertsCardConfig {
   animations?: boolean;  // undefined: respects prefers-reduced-motion; true: always animate; false: never animate
   progressStyle?: ProgressStyleConfig; // per-phase progress-bar decoration; omit for defaults (prep striped, active shimmer, ongoing pulse)
   iconBorderStyle?: IconBorderStyleConfig; // per-phase icon-ring border style; omit for defaults (prep dashed, active solid, ongoing solid)
+  tap_action?: ActionConfig; // standard HA action fired when an alert row is tapped; presence replaces the inline expand/toggle affordance in both layouts. Absent = unchanged inline-expand behavior
   layout?: 'default' | 'compact';
   fontSize?: 'small' | 'default' | 'large' | 'x-large';
   progressFill?: 'track' | 'background'; // undefined/'track': thin progress bar (full) / bottom mini-bar (compact); 'background': Bubble-Card-style whole-row low-opacity wash growing to --progress, behind the content (thin track hidden, labels kept)
@@ -152,6 +186,7 @@ export interface DismissalRecord {
 // Normalized alert consumed by the card UI — provider-agnostic
 export interface WeatherAlert {
   id: string;
+  sourceEntityId?: string; // entity_id this alert was parsed from; stamped during collection, consumed for per-alert tap_action more-info/toggle targeting
   event: string;           // e.g. "Severe Thunderstorm Warning"
   severity: AlertSeverity;
   severityLabel: string;   // Human-readable severity label from provider (e.g. "Moderate", "Major")

--- a/src/weather-alerts-card.ts
+++ b/src/weather-alerts-card.ts
@@ -58,6 +58,7 @@ import {
   DEFAULT_TILE_ATTRIBUTION,
   GeoJsonGeometry,
 } from './geometry';
+import { handleTapAction, hasTapAction } from './actions';
 import { t } from './localize';
 import { cardStyles } from './styles';
 import './weather-alerts-card-editor';
@@ -524,7 +525,9 @@ export class WeatherAlertsCard extends LitElement {
         seenProviders.add(adapter.provider);
         providerPriority.push(adapter.provider);
       }
-      allAlerts.push(...adapter.parseAlerts(entity.attributes));
+      const parsed = adapter.parseAlerts(entity.attributes);
+      for (const a of parsed) a.sourceEntityId = entityId;
+      allAlerts.push(...parsed);
     }
     let filtered = this._filterAndSort(allAlerts, { providerPriority });
     if (this._config.allowDismiss && !this._forcePreview && this._dismissals.size > 0) {
@@ -928,6 +931,27 @@ export class WeatherAlertsCard extends LitElement {
     }
   }
 
+  // Fire the configured tap_action for the tapped alert row. Resolves the
+  // more-info/toggle default entity per-alert: the tapped alert's own source
+  // sensor, falling back to the primary config entity.
+  private _onCardAction(alert: WeatherAlert): void {
+    // Swallow the click synthesized at the end of a swipe-dismiss drag, exactly
+    // as _toggleDetails does — the action must not fire on a swipe.
+    if (this._swipeJustDragged) {
+      this._swipeJustDragged = false;
+      return;
+    }
+    const cfg = this._config?.tap_action;
+    if (!cfg || cfg.action === 'none') return;
+    handleTapAction(this, this.hass, cfg, alert.sourceEntityId ?? this._config?.entity);
+  }
+
+  private _onCardActionKeydown(alert: WeatherAlert, e: KeyboardEvent): void {
+    if (e.key !== 'Enter' && e.key !== ' ' && e.key !== 'Spacebar') return;
+    e.preventDefault();
+    this._onCardAction(alert);
+  }
+
   private _sourceLinkLabel(alert: WeatherAlert): string {
     const label = PROVIDER_LABELS[alert.provider] || 'Alert';
     return t('card.open_source', this._lang, { provider: label });
@@ -1166,19 +1190,25 @@ export class WeatherAlertsCard extends LitElement {
     const decoClasses = this._alertDecoClasses(progress);
     const progressStyle = isOngoing ? '' : `--progress: ${progress.progressPct}%;`;
     const swipeClass = this._swipeCardClass(alert);
+    const tapAction = hasTapAction(this._config);
+    const actionable = tapAction && this._config!.tap_action!.action !== 'none';
     const cardStyle = this._swipeCardStyle(alert, `${this._alertColorStyle(alert)} ${progressStyle}`);
     return html`
       <div
-        class="alert-card ${className} ${phaseClass} ${ongoingClass} ${decoClasses} ${boostClasses} ${swipeClass}"
+        class="alert-card ${className} ${phaseClass} ${ongoingClass} ${decoClasses} ${boostClasses} ${swipeClass} ${actionable ? 'tappable' : ''}"
         style=${cardStyle}
+        role=${actionable ? 'button' : nothing}
+        tabindex=${actionable ? '0' : nothing}
         @pointerdown=${(e: PointerEvent) => this._onSwipePointerDown(alert, e)}
         @pointermove=${(e: PointerEvent) => this._onSwipePointerMove(alert, e)}
         @pointerup=${(e: PointerEvent) => this._onSwipePointerUp(alert, e)}
         @pointercancel=${(e: PointerEvent) => this._onSwipePointerCancel(alert, e)}
+        @click=${actionable ? () => this._onCardAction(alert) : nothing}
+        @keydown=${actionable ? (e: KeyboardEvent) => this._onCardActionKeydown(alert, e) : nothing}
       >
         <div
           class="alert-header-row compact-row"
-          @click=${() => this._toggleDetails(alert.id)}
+          @click=${tapAction ? nothing : () => this._toggleDetails(alert.id)}
         >
           <div class="icon-box">
             <ha-icon icon=${alert.providerIcon ?? getWeatherIcon(alert.iconHint || alert.event)}></ha-icon>
@@ -1186,10 +1216,12 @@ export class WeatherAlertsCard extends LitElement {
           ${this._renderProviderHint(alert)}
           <span class="alert-title">${alert.event}</span>
           <span class="compact-time">${compactTimeLabel}</span>
+          ${tapAction ? nothing : html`
           <ha-icon
             icon="mdi:chevron-down"
             class="compact-chevron ${expanded ? 'expanded' : ''}"
           ></ha-icon>
+          `}
           ${this._renderDismissButton(alert)}
         </div>
         ${expanded ? this._renderExpandedContent(alert, progress) : nothing}
@@ -1243,6 +1275,8 @@ export class WeatherAlertsCard extends LitElement {
     const boostClasses = this._alertBoostClasses(alert);
     const decoClasses = this._alertDecoClasses(progress);
     const swipeClass = this._swipeCardClass(alert);
+    const tapAction = hasTapAction(this._config);
+    const actionable = tapAction && this._config!.tap_action!.action !== 'none';
     // --progress positions the whole-row wash (progressFill:background); ongoing
     // (active, no end time) fills full-width, so pin it to 0% (left:0). Inert in
     // track mode. Mirrors the compact renderer.
@@ -1251,12 +1285,16 @@ export class WeatherAlertsCard extends LitElement {
     const cardStyle = this._swipeCardStyle(alert, `${this._alertColorStyle(alert)} ${progressStyle}`);
     return html`
       <div
-        class="alert-card ${className} ${phaseClass} ${decoClasses} ${boostClasses} ${swipeClass}"
+        class="alert-card ${className} ${phaseClass} ${decoClasses} ${boostClasses} ${swipeClass} ${actionable ? 'tappable' : ''}"
         style=${cardStyle}
+        role=${actionable ? 'button' : nothing}
+        tabindex=${actionable ? '0' : nothing}
         @pointerdown=${(e: PointerEvent) => this._onSwipePointerDown(alert, e)}
         @pointermove=${(e: PointerEvent) => this._onSwipePointerMove(alert, e)}
         @pointerup=${(e: PointerEvent) => this._onSwipePointerUp(alert, e)}
         @pointercancel=${(e: PointerEvent) => this._onSwipePointerCancel(alert, e)}
+        @click=${actionable ? () => this._onCardAction(alert) : nothing}
+        @keydown=${actionable ? (e: KeyboardEvent) => this._onCardActionKeydown(alert, e) : nothing}
       >
         <div class="alert-header-row">
           <div class="icon-box">
@@ -1283,7 +1321,11 @@ export class WeatherAlertsCard extends LitElement {
 
         ${this._renderProgressSection(alert, progress)}
 
-        ${this._config?.showDetails !== false ? (this._config?.expandDetails ? html`
+        ${tapAction
+          ? (this._config?.showDetails !== false && this._config?.expandDetails
+            ? this._renderDetailsContent(alert, progress)
+            : nothing)
+          : (this._config?.showDetails !== false ? (this._config?.expandDetails ? html`
         ${this._renderDetailsContent(alert, progress)}
         ` : html`
         <div class="alert-details-section">
@@ -1299,7 +1341,7 @@ export class WeatherAlertsCard extends LitElement {
           </div>
           ${expanded ? this._renderDetailsContent(alert, progress) : nothing}
         </div>
-        `) : nothing}
+        `) : nothing)}
       </div>
     `;
   }
@@ -1374,7 +1416,7 @@ export class WeatherAlertsCard extends LitElement {
     const lang = this._lang;
 
     return html`
-      <div class="details-content">
+      <div class="details-content" @click=${(e: Event) => e.stopPropagation()}>
         ${this._config?.showMetadata !== false ? html`
         <div class="meta-grid">
           ${progress.sentTs > 100 ? html`

--- a/tests/card-tap-action.test.ts
+++ b/tests/card-tap-action.test.ts
@@ -173,7 +173,7 @@ describe('handleTapAction dispatcher', () => {
   it('url opens window with url_path', () => {
     const open = vi.spyOn(window, 'open').mockImplementation(() => null);
     handleTapAction(node(), undefined, { action: 'url', url_path: 'https://example.test/' });
-    expect(open).toHaveBeenCalledWith('https://example.test/');
+    expect(open).toHaveBeenCalledWith('https://example.test/', '_blank', 'noopener');
     open.mockRestore();
   });
 

--- a/tests/card-tap-action.test.ts
+++ b/tests/card-tap-action.test.ts
@@ -1,0 +1,446 @@
+import { describe, it, expect, beforeAll, beforeEach, vi } from 'vitest';
+
+// jsdom lacks matchMedia; the card touches it during construction, so the
+// polyfill must be installed before the card module loads.
+beforeAll(() => {
+  if (!window.matchMedia) {
+    Object.defineProperty(window, 'matchMedia', {
+      writable: true,
+      value: () => ({
+        matches: false,
+        media: '',
+        onchange: null,
+        addEventListener: () => {},
+        removeEventListener: () => {},
+        addListener: () => {},
+        removeListener: () => {},
+        dispatchEvent: () => false,
+      }),
+    });
+  }
+});
+
+import { WeatherAlertsCard } from '../src/weather-alerts-card';
+import { handleTapAction, hasTapAction, fireEvent } from '../src/actions';
+import type { ActionConfig, HomeAssistant, WeatherAlertsCardConfig } from '../src/types';
+
+const HOUR = 3600 * 1000;
+
+interface CardInternals {
+  setConfig(config: WeatherAlertsCardConfig): void;
+  hass: HomeAssistant;
+  shadowRoot: ShadowRoot | null;
+  remove(): void;
+  _swipeJustDragged: boolean;
+}
+
+// One aggregate NWS sensor — every parsed alert's sourceEntityId is this sensor.
+function nwsHass(): HomeAssistant {
+  const now = Date.now();
+  return {
+    states: {
+      'sensor.nws_alerts': {
+        state: '1',
+        attributes: {
+          Alerts: [{
+            ID: 'wind-severe',
+            Event: 'High Wind Warning',
+            Severity: 'Severe',
+            Sent: new Date(now - 2 * HOUR).toISOString(),
+            Onset: new Date(now - 1 * HOUR).toISOString(),
+            Ends: new Date(now + 3 * HOUR).toISOString(),
+            Expires: new Date(now + 3 * HOUR).toISOString(),
+            Description: 'Damaging winds.',
+            Instruction: 'Take cover.',
+            URL: 'https://example.test/wind',
+            Headline: '',
+          }],
+        },
+      },
+    },
+    locale: { language: 'en' },
+  } as unknown as HomeAssistant;
+}
+
+// Two CAP per-alert sensors — each alert carries its own sourceEntityId.
+function capAttrs(id: string, event: string): Record<string, unknown> {
+  const now = Date.now();
+  return {
+    incident_platform_version: '1.0',
+    id,
+    event,
+    severity: 'Moderate',
+    severity_normalized: 'moderate',
+    sent: new Date(now - 2 * HOUR).toISOString(),
+    expires: new Date(now + 3 * HOUR).toISOString(),
+  };
+}
+
+function capTwoEntityHass(): HomeAssistant {
+  return {
+    states: {
+      'sensor.cap_frost': { state: 'moderate', attributes: capAttrs('urn:frost', 'Frost') },
+      'sensor.cap_flood': { state: 'moderate', attributes: capAttrs('urn:flood', 'Flood') },
+    },
+    locale: { language: 'en' },
+  } as unknown as HomeAssistant;
+}
+
+async function mountCard(
+  config: WeatherAlertsCardConfig,
+  hass: HomeAssistant,
+): Promise<{ card: CardInternals; cleanup: () => void }> {
+  const card = document.createElement('weather-alerts-card') as unknown as CardInternals;
+  card.setConfig(config);
+  card.hass = hass;
+  document.body.appendChild(card);
+  await (card as unknown as { updateComplete: Promise<void> }).updateComplete;
+  return { card, cleanup: () => card.remove() };
+}
+
+function root(card: CardInternals): ShadowRoot {
+  if (!card.shadowRoot) throw new Error('no shadowRoot');
+  return card.shadowRoot;
+}
+
+beforeEach(() => {
+  // The card persists per-alert expand state in a static map keyed by entity;
+  // clear it so expansion from one test never leaks into the next.
+  (WeatherAlertsCard as unknown as { _editorExpandedState: Map<string, unknown> })
+    ._editorExpandedState.clear();
+
+  const store = new Map<string, string>();
+  Object.defineProperty(globalThis, 'localStorage', {
+    value: {
+      get length() { return store.size; },
+      clear: () => store.clear(),
+      getItem: (k: string) => (store.has(k) ? store.get(k)! : null),
+      setItem: (k: string, v: string) => { store.set(k, String(v)); },
+      removeItem: (k: string) => { store.delete(k); },
+      key: (i: number) => Array.from(store.keys())[i] ?? null,
+    },
+    configurable: true,
+    writable: true,
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Dispatcher unit tests
+// ---------------------------------------------------------------------------
+
+describe('handleTapAction dispatcher', () => {
+  const node = () => document.createElement('div');
+
+  function fakeHass(): { hass: HomeAssistant; calls: unknown[][] } {
+    const calls: unknown[][] = [];
+    const hass = {
+      callService: (...args: unknown[]) => { calls.push(args); return Promise.resolve(); },
+    } as unknown as HomeAssistant;
+    return { hass, calls };
+  }
+
+  it('more-info fires hass-more-info with action.entity, else defaultEntity, else nothing', () => {
+    const n = node();
+    const seen: string[] = [];
+    n.addEventListener('hass-more-info', (e) => seen.push((e as CustomEvent).detail.entityId));
+
+    handleTapAction(n, undefined, { action: 'more-info', entity: 'light.explicit' }, 'sensor.default');
+    handleTapAction(n, undefined, { action: 'more-info' }, 'sensor.default');
+    handleTapAction(n, undefined, { action: 'more-info' }); // neither → no event
+
+    expect(seen).toEqual(['light.explicit', 'sensor.default']);
+  });
+
+  it('navigate pushes state and fires location-changed; honors navigation_replace', () => {
+    const push = vi.spyOn(history, 'pushState');
+    const replace = vi.spyOn(history, 'replaceState');
+    const events: boolean[] = [];
+    const onNav = (e: Event) => events.push((e as CustomEvent).detail.replace);
+    window.addEventListener('location-changed', onNav);
+
+    handleTapAction(node(), undefined, { action: 'navigate', navigation_path: '#alerts' });
+    handleTapAction(node(), undefined, { action: 'navigate', navigation_path: '#x', navigation_replace: true });
+
+    expect(push).toHaveBeenCalledWith(null, '', '#alerts');
+    expect(replace).toHaveBeenCalledWith(null, '', '#x');
+    expect(events).toEqual([false, true]);
+
+    window.removeEventListener('location-changed', onNav);
+    push.mockRestore();
+    replace.mockRestore();
+  });
+
+  it('url opens window with url_path', () => {
+    const open = vi.spyOn(window, 'open').mockImplementation(() => null);
+    handleTapAction(node(), undefined, { action: 'url', url_path: 'https://example.test/' });
+    expect(open).toHaveBeenCalledWith('https://example.test/');
+    open.mockRestore();
+  });
+
+  it('toggle calls homeassistant.toggle with the resolved entity', () => {
+    const { hass, calls } = fakeHass();
+    handleTapAction(node(), hass, { action: 'toggle' }, 'switch.fan');
+    expect(calls).toEqual([['homeassistant', 'toggle', { entity_id: 'switch.fan' }]]);
+  });
+
+  it('call-service and perform-action both split the service and pass data/target', () => {
+    const a = fakeHass();
+    handleTapAction(node(), a.hass, {
+      action: 'call-service', service: 'notify.mobile', data: { message: 'hi' }, target: { x: 1 },
+    });
+    expect(a.calls).toEqual([['notify', 'mobile', { message: 'hi' }, { x: 1 }]]);
+
+    const b = fakeHass();
+    handleTapAction(node(), b.hass, {
+      action: 'perform-action', perform_action: 'light.turn_on', service_data: { brightness: 5 },
+    });
+    expect(b.calls).toEqual([['light', 'turn_on', { brightness: 5 }, undefined]]);
+  });
+
+  it('fire-dom-event fires ll-custom carrying the whole config', () => {
+    const n = node();
+    let detail: unknown;
+    n.addEventListener('ll-custom', (e) => { detail = (e as CustomEvent).detail; });
+    const cfg: ActionConfig = { action: 'fire-dom-event', browser_mod: { service: 'popup' } };
+    handleTapAction(n, undefined, cfg);
+    expect(detail).toEqual(cfg);
+  });
+
+  it('none and unknown actions fire nothing', () => {
+    const n = node();
+    let fired = false;
+    ['hass-more-info', 'll-custom', 'location-changed'].forEach(
+      t => n.addEventListener(t, () => { fired = true; }),
+    );
+    handleTapAction(n, undefined, { action: 'none' });
+    handleTapAction(n, undefined, { action: 'bogus' } as unknown as ActionConfig);
+    expect(fired).toBe(false);
+  });
+
+  it('hasTapAction is presence-based (true even for action:none)', () => {
+    expect(hasTapAction(undefined)).toBe(false);
+    expect(hasTapAction({})).toBe(false);
+    expect(hasTapAction({ tap_action: { action: 'none' } })).toBe(true);
+    expect(hasTapAction({ tap_action: { action: 'more-info' } })).toBe(true);
+  });
+
+  it('fireEvent dispatches a composed bubbling CustomEvent', () => {
+    const n = node();
+    let ev: CustomEvent | undefined;
+    n.addEventListener('x-test', (e) => { ev = e as CustomEvent; });
+    fireEvent(n, 'x-test', { a: 1 });
+    expect(ev?.bubbles).toBe(true);
+    expect(ev?.composed).toBe(true);
+    expect(ev?.detail).toEqual({ a: 1 });
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Render / behavior tests
+// ---------------------------------------------------------------------------
+
+function baseFull(extra: Partial<WeatherAlertsCardConfig> = {}): WeatherAlertsCardConfig {
+  return {
+    type: 'custom:weather-alerts-card',
+    entity: 'sensor.nws_alerts',
+    ...extra,
+  } as WeatherAlertsCardConfig;
+}
+
+describe('back-compat (no tap_action)', () => {
+  it('compact row keeps the chevron and toggles expand on click', async () => {
+    const { card, cleanup } = await mountCard(
+      baseFull({ layout: 'compact' }), nwsHass(),
+    );
+    const r = root(card);
+    expect(r.querySelector('.compact-chevron')).not.toBeNull();
+    expect(r.querySelector('.alert-card.tappable')).toBeNull();
+    expect(r.querySelector('.alert-expanded')).toBeNull();
+
+    r.querySelector<HTMLElement>('.compact-row')!.click();
+    await (card as unknown as { updateComplete: Promise<void> }).updateComplete;
+    expect(r.querySelector('.alert-expanded')).not.toBeNull();
+    cleanup();
+  });
+
+  it('full row keeps the Read details toggle', async () => {
+    const { card, cleanup } = await mountCard(baseFull(), nwsHass());
+    expect(root(card).querySelector('.details-summary')).not.toBeNull();
+    expect(root(card).querySelector('.alert-card.tappable')).toBeNull();
+    cleanup();
+  });
+});
+
+describe('compact + tap_action', () => {
+  it('drops the chevron, does not expand, and fires the action on click', async () => {
+    const { card, cleanup } = await mountCard(
+      baseFull({ layout: 'compact', tap_action: { action: 'more-info' } }), nwsHass(),
+    );
+    const r = root(card);
+    expect(r.querySelector('.compact-chevron')).toBeNull();
+
+    const seen: string[] = [];
+    window.addEventListener('hass-more-info', (e) => seen.push((e as CustomEvent).detail.entityId));
+
+    r.querySelector<HTMLElement>('.compact-row')!.click();
+    await (card as unknown as { updateComplete: Promise<void> }).updateComplete;
+
+    expect(r.querySelector('.alert-expanded')).toBeNull();
+    // Aggregate provider → the alert's sourceEntityId is the aggregate sensor.
+    expect(seen).toEqual(['sensor.nws_alerts']);
+    cleanup();
+  });
+});
+
+describe('full + tap_action', () => {
+  it('with no expandDetails: no toggle, row click fires the action', async () => {
+    const { card, cleanup } = await mountCard(
+      baseFull({ tap_action: { action: 'more-info' } }), nwsHass(),
+    );
+    const r = root(card);
+    expect(r.querySelector('.details-summary')).toBeNull();
+    expect(r.querySelector('.details-content')).toBeNull();
+    expect(r.querySelector('.alert-card.tappable')).not.toBeNull();
+
+    const seen: string[] = [];
+    window.addEventListener('hass-more-info', (e) => seen.push((e as CustomEvent).detail.entityId));
+    r.querySelector<HTMLElement>('.alert-card')!.click();
+    expect(seen).toEqual(['sensor.nws_alerts']);
+    cleanup();
+  });
+
+  it('with expandDetails: static panel shows; clicking a link inside it does not fire the row action', async () => {
+    const { card, cleanup } = await mountCard(
+      baseFull({ tap_action: { action: 'more-info' }, expandDetails: true }), nwsHass(),
+    );
+    const r = root(card);
+    expect(r.querySelector('.details-summary')).toBeNull(); // no toggle
+    const panel = r.querySelector<HTMLElement>('.details-content');
+    expect(panel).not.toBeNull();
+
+    const seen: string[] = [];
+    window.addEventListener('hass-more-info', (e) => seen.push((e as CustomEvent).detail.entityId));
+
+    panel!.click(); // stopPropagation guard → no row action
+    expect(seen).toEqual([]);
+
+    r.querySelector<HTMLElement>('.alert-header-row')!.click(); // the row → action
+    expect(seen).toEqual(['sensor.nws_alerts']);
+    cleanup();
+  });
+});
+
+describe('per-alert entity resolution', () => {
+  it('each CAP row fires more-info for its own source sensor', async () => {
+    const { card, cleanup } = await mountCard(
+      {
+        type: 'custom:weather-alerts-card',
+        entity: 'sensor.cap_frost',
+        entities: ['sensor.cap_flood'],
+        tap_action: { action: 'more-info' },
+      } as WeatherAlertsCardConfig,
+      capTwoEntityHass(),
+    );
+    const r = root(card);
+    const cards = r.querySelectorAll<HTMLElement>('.alert-card');
+    expect(cards.length).toBe(2);
+
+    const seen: string[] = [];
+    window.addEventListener('hass-more-info', (e) => seen.push((e as CustomEvent).detail.entityId));
+    cards.forEach(c => c.click());
+
+    expect(seen.sort()).toEqual(['sensor.cap_flood', 'sensor.cap_frost']);
+    cleanup();
+  });
+
+  it('explicit tap_action.entity overrides the per-alert source', async () => {
+    const { card, cleanup } = await mountCard(
+      {
+        type: 'custom:weather-alerts-card',
+        entity: 'sensor.cap_frost',
+        entities: ['sensor.cap_flood'],
+        tap_action: { action: 'more-info', entity: 'sensor.override' },
+      } as WeatherAlertsCardConfig,
+      capTwoEntityHass(),
+    );
+    const r = root(card);
+    const seen: string[] = [];
+    window.addEventListener('hass-more-info', (e) => seen.push((e as CustomEvent).detail.entityId));
+    r.querySelectorAll<HTMLElement>('.alert-card').forEach(c => c.click());
+    expect(seen).toEqual(['sensor.override', 'sensor.override']);
+    cleanup();
+  });
+});
+
+describe('action: none (inert chip)', () => {
+  it('removes the expand affordance but is not tappable and fires nothing', async () => {
+    const { card, cleanup } = await mountCard(
+      baseFull({ tap_action: { action: 'none' } }), nwsHass(),
+    );
+    const r = root(card);
+    expect(r.querySelector('.details-summary')).toBeNull();
+    expect(r.querySelector('.alert-card.tappable')).toBeNull();
+    expect(r.querySelector('.alert-card')!.getAttribute('role')).toBeNull();
+
+    const seen: string[] = [];
+    window.addEventListener('hass-more-info', () => seen.push('x'));
+    r.querySelector<HTMLElement>('.alert-card')!.click();
+    expect(seen).toEqual([]);
+    cleanup();
+  });
+});
+
+describe('swipe guard', () => {
+  it('a click after a swipe drag fires no action and resets the flag', async () => {
+    const { card, cleanup } = await mountCard(
+      baseFull({ tap_action: { action: 'more-info' } }), nwsHass(),
+    );
+    const r = root(card);
+    const seen: string[] = [];
+    window.addEventListener('hass-more-info', (e) => seen.push((e as CustomEvent).detail.entityId));
+
+    card._swipeJustDragged = true;
+    r.querySelector<HTMLElement>('.alert-card')!.click();
+    expect(seen).toEqual([]);
+    expect(card._swipeJustDragged).toBe(false);
+
+    // A subsequent genuine click now fires.
+    r.querySelector<HTMLElement>('.alert-card')!.click();
+    expect(seen).toEqual(['sensor.nws_alerts']);
+    cleanup();
+  });
+});
+
+describe('dismiss button', () => {
+  it('clicking × does not fire the row action', async () => {
+    const { card, cleanup } = await mountCard(
+      baseFull({ tap_action: { action: 'more-info' }, allowDismiss: true }), nwsHass(),
+    );
+    const r = root(card);
+    const seen: string[] = [];
+    window.addEventListener('hass-more-info', (e) => seen.push((e as CustomEvent).detail.entityId));
+
+    const btn = r.querySelector<HTMLElement>('.dismiss-button');
+    expect(btn).not.toBeNull();
+    btn!.click();
+    expect(seen).toEqual([]);
+    cleanup();
+  });
+});
+
+describe('accessibility', () => {
+  it('actionable row is a keyboard-operable button and Enter fires the action', async () => {
+    const { card, cleanup } = await mountCard(
+      baseFull({ tap_action: { action: 'more-info' } }), nwsHass(),
+    );
+    const el = root(card).querySelector<HTMLElement>('.alert-card')!;
+    expect(el.getAttribute('role')).toBe('button');
+    expect(el.getAttribute('tabindex')).toBe('0');
+
+    const seen: string[] = [];
+    window.addEventListener('hass-more-info', (e) => seen.push((e as CustomEvent).detail.entityId));
+    el.dispatchEvent(new KeyboardEvent('keydown', { key: 'Enter', bubbles: true }));
+    expect(seen).toEqual(['sensor.nws_alerts']);
+    cleanup();
+  });
+});


### PR DESCRIPTION
Implements the card-owner's committed half of #189: a configurable `tap_action` so a compact chip (or any alert row) can trigger a Home Assistant action — the missing piece that lets the card open a Bubble Card pop-up (`navigate` to `#hash`) or fire a `browser_mod` event (`fire-dom-event`) instead of only expanding inline.

Follows the approved plan in `plans/tap-action.md` (Strategy B — hand-rolled dispatch, no new dependency; tap-only; YAML-only; whole-row → action, drop the inline toggle).

## Behavior
- New optional `tap_action` accepting the standard HA action schema.
- **When set:** the whole alert row becomes the tap target; the compact chevron / "Read Details" toggle is removed in both layouts. In the default layout `expandDetails: true` still renders the always-on detail panel (its links don't trigger the row action). `action: none` is a valid inert chip.
- **When absent:** byte-for-byte unchanged — the critical back-compat contract.
- Supported: `more-info`, `navigate`, `url`, `toggle`, `call-service` (alias `perform-action`), `fire-dom-event`, `none`. `assist` intentionally excluded.

### Per-alert entity resolution (more-info / toggle)
`tap_action.entity` → the tapped alert's own `sourceEntityId` (stamped during collection) → `config.entity`. CAP Alerts / NSW RFS rows open *their* sensor; aggregate providers (NWS, DWD, …) degrade to the aggregate sensor. No regression — absent `tap_action`, `sourceEntityId` is never read.

## Changes
- **New** `src/actions.ts` — dependency-free `fireEvent` / `hasTapAction` / `handleTapAction`. No `custom-card-helpers` (bundle discipline, #194).
- **New** `tests/card-tap-action.test.ts` — 20 tests (dispatcher units + entity resolution + card render/behavior: back-compat, compact/full branching, `action:none`, swipe guard, dismiss button, a11y).
- `src/types.ts` — `ActionConfig`; `tap_action?`; `sourceEntityId?` on `WeatherAlert`; `callService?` on `HomeAssistant`.
- `src/weather-alerts-card.ts` — stamp `sourceEntityId`; `_onCardAction`/`_onCardActionKeydown` (reuse `_swipeJustDragged`); branch both renderers on `tap_action` presence; `stopPropagation` on `.details-content`.
- `src/styles.ts` — `.alert-card.tappable` cursor + `:focus-visible` outline.
- `README.md` — config-table row + Bubble pop-up recipe.

## Verification
- `tsc --noEmit` clean
- Full suite **702 passed** (up from 682; back-compat `card-details.test.ts` still green)
- `rollup -c` builds

The `navigate` → Bubble pop-up path was validated manually against a live Bubble pop-up per the plan; it's the one thing not covered by automated tests.

## Follow-up commits (added after this PR opened)
- **`fix(actions)`** — the `url` tap action now opens with `_blank` + `noopener` (reverse-tabnabbing hardening); dispatcher test updated. Suite still **702 passed**.
- **`docs(screenshots)`** — new `scripts/screenshot-tap-action.html` harness rendering the Bubble Card pop-up recipe figure (a dimmed dashboard chip → a Bubble pop-up wrapping a **transparent** full-detail card via the `--wac-*` surface tokens, severity promoted to a full-height left spine), wired into `screenshot.js` + `encode-adaptive-svgs.sh`. Generated figures/animations are produced on demand and **intentionally not committed** — the first step of moving figure media to a CI-generated docs site.

Assisted-by: Claude:claude-opus-4-8
