### PR TITLE
feat: per-alert detail pop-up (tap_action: { action: details })

### DIFF
--- a/README.md
+++ b/README.md
@@ -104,6 +104,30 @@ Deeper layout tweaks (row height, icon chip size) still require reaching into th
 card's internal class names, which are **not** a stable public API and may change
 between releases. Prefer the tokens above where they suffice.
 
+**Per-alert detail pop-up (built in)** — `tap_action: { action: details }` opens
+the tapped alert's expanded-details view in a modal instead of expanding it in
+place. No add-ons required, and it is genuinely per-alert for **every** provider:
+the card renders the alert object it already has, so an aggregate sensor holding
+five warnings still gives you five distinct pop-ups. Works in both `layout:
+default` and `compact`, and the dialog respects the same `showDetails` /
+`showMetadata` / `showGeometry` / `expandDetails` switches the inline expand does
+— set `expandDetails: true` if you want the description open on arrival rather
+than behind the "Read Details" toggle.
+
+```yaml
+type: custom:weather-alerts-card
+entity: sensor.nws_alerts_alerts
+provider: nws
+layout: compact
+expandDetails: true
+tap_action:
+  action: details
+```
+
+Prefer this over the Bubble/`browser_mod` recipes below unless you specifically
+want their pop-up chrome — both remain available via `navigate` and
+`fire-dom-event`.
+
 **Bubble Card pop-up** — send the compact layout's rows to a
 [Bubble Card](https://github.com/Clooos/Bubble-Card) pop-up instead of expanding
 inline. `tap_action` navigates to the pop-up's hash; the second card *is* the
@@ -115,9 +139,9 @@ Two things to know before wiring this up:
 - **The pop-up is shared, not per-alert.** A Bubble hash addresses one static
   pop-up, so every row navigates to the same one and it shows *all* current
   alerts in full detail — not only the alert you tapped. Per-alert scoping can't
-  be expressed with a hash. To open the tapped alert's own sensor instead, use
-  `tap_action: { action: more-info }`, which opens Home Assistant's native dialog
-  for it.
+  be expressed with a hash — that is exactly what `action: details` above is for.
+  To open the tapped alert's own HA entity dialog instead, use
+  `tap_action: { action: more-info }`.
 - **`layout: compact` renders one row per alert**, not a single summary chip.
   With three active alerts you get three entry rows, all tapping through to the
   same pop-up.
@@ -217,7 +241,7 @@ Then click the Download button, and click Reload when prompted.
 | `dismissTrigger` | `'button'` | `'button'`, `'swipe'`, or `'both'` — how an alert is dismissed (swipe covers touch + mouse drag). Requires `allowDismiss` |
 | `dismissButtonStyle` | `'icon'` | `'icon'` or `'labeled'` (icon + "Dismiss" text). No effect when `dismissTrigger: 'swipe'`; compact layout is always icon-only |
 | `showDismissUndo` | `true` | Show an Undo toast when an alert is dismissed. No effect when `allowDismiss` is off |
-| `tap_action` | — | Standard Home Assistant action fired when an alert row is tapped. **When set, the inline expand affordance is replaced** — the whole row becomes the tap target and the compact chevron / "Read Details" toggle is removed (in the default layout, `expandDetails: true` still renders the always-on detail panel below the row). Supported actions: `more-info`, `navigate`, `url`, `toggle`, `call-service` (alias `perform-action`), `fire-dom-event`, `none` (`assist` is intentionally unsupported — it has no meaning on an alert row; `none` is an inert chip: the toggle is removed but tapping does nothing). For `more-info`/`toggle`, the default entity is resolved **per tapped alert** — `tap_action.entity` (explicit) → the alert's own source sensor → `entity` — so per-alert providers (CAP Alerts, NSW RFS) open *that* alert's sensor while aggregate providers (NWS, DWD, …) fall back to the aggregate sensor. `toggle` uses the generic `homeassistant.toggle` service. Absent = today's inline expand/toggle behavior, unchanged. |
+| `tap_action` | — | Standard Home Assistant action fired when an alert row is tapped. **When set, the inline expand affordance is replaced** — the whole row becomes the tap target and the compact chevron / "Read Details" toggle is removed (in the default layout, `expandDetails: true` still renders the always-on detail panel below the row). Supported actions: `details`, `more-info`, `navigate`, `url`, `toggle`, `call-service` (alias `perform-action`), `fire-dom-event`, `none` (`assist` is intentionally unsupported — it has no meaning on an alert row; `none` is an inert chip: the toggle is removed but tapping does nothing). For `more-info`/`toggle`, the default entity is resolved **per tapped alert** — `tap_action.entity` (explicit) → the alert's own source sensor → `entity` — so per-alert providers (CAP Alerts, NSW RFS) open *that* alert's sensor while aggregate providers (NWS, DWD, …) fall back to the aggregate sensor. `toggle` uses the generic `homeassistant.toggle` service. `details` is card-owned rather than a standard HA action: it opens the tapped alert's expanded-details view in a modal (per-alert for every provider, no add-ons — see [Themes](#themes) for an example). Absent = today's inline expand/toggle behavior, unchanged. |
 
 <details>
 <summary><strong>Examples</strong></summary>

--- a/README.md
+++ b/README.md
@@ -105,21 +105,24 @@ card's internal class names, which are **not** a stable public API and may chang
 between releases. Prefer the tokens above where they suffice.
 
 **Per-alert detail pop-up (built in)** — `tap_action: { action: details }` opens
-the tapped alert's expanded-details view in a modal instead of expanding it in
-place. No add-ons required, and it is genuinely per-alert for **every** provider:
-the card renders the alert object it already has, so an aggregate sensor holding
-five warnings still gives you five distinct pop-ups. Works in both `layout:
-default` and `compact`, and the dialog respects the same `showDetails` /
-`showMetadata` / `showGeometry` / `expandDetails` switches the inline expand does
-— set `expandDetails: true` if you want the description open on arrival rather
-than behind the "Read Details" toggle.
+the tapped alert in a modal instead of expanding it in place. No add-ons
+required, and it is genuinely per-alert for **every** provider: the card renders
+the alert object it already has, so an aggregate sensor holding five warnings
+still gives you five distinct pop-ups. Works in both `layout: default` and
+`compact`.
+
+The pop-up shows the **whole alert** — icon, title, headline, area, badges,
+progress bar, metadata and the full description/instructions — and since the
+pop-up *is* the detail view, the description is always open inside it (no
+"Read Details" toggle to click). `showDetails` / `showMetadata` /
+`showDescription` / `showInstructions` / `showGeometry` still apply;
+`expandDetails` governs the row only, not the pop-up.
 
 ```yaml
 type: custom:weather-alerts-card
 entity: sensor.nws_alerts_alerts
 provider: nws
 layout: compact
-expandDetails: true
 tap_action:
   action: details
 ```
@@ -241,7 +244,7 @@ Then click the Download button, and click Reload when prompted.
 | `dismissTrigger` | `'button'` | `'button'`, `'swipe'`, or `'both'` — how an alert is dismissed (swipe covers touch + mouse drag). Requires `allowDismiss` |
 | `dismissButtonStyle` | `'icon'` | `'icon'` or `'labeled'` (icon + "Dismiss" text). No effect when `dismissTrigger: 'swipe'`; compact layout is always icon-only |
 | `showDismissUndo` | `true` | Show an Undo toast when an alert is dismissed. No effect when `allowDismiss` is off |
-| `tap_action` | — | Standard Home Assistant action fired when an alert row is tapped. **When set, the inline expand affordance is replaced** — the whole row becomes the tap target and the compact chevron / "Read Details" toggle is removed (in the default layout, `expandDetails: true` still renders the always-on detail panel below the row). Supported actions: `details`, `more-info`, `navigate`, `url`, `toggle`, `call-service` (alias `perform-action`), `fire-dom-event`, `none` (`assist` is intentionally unsupported — it has no meaning on an alert row; `none` is an inert chip: the toggle is removed but tapping does nothing). For `more-info`/`toggle`, the default entity is resolved **per tapped alert** — `tap_action.entity` (explicit) → the alert's own source sensor → `entity` — so per-alert providers (CAP Alerts, NSW RFS) open *that* alert's sensor while aggregate providers (NWS, DWD, …) fall back to the aggregate sensor. `toggle` uses the generic `homeassistant.toggle` service. `details` is card-owned rather than a standard HA action: it opens the tapped alert's expanded-details view in a modal (per-alert for every provider, no add-ons — see [Themes](#themes) for an example). Absent = today's inline expand/toggle behavior, unchanged. |
+| `tap_action` | — | Standard Home Assistant action fired when an alert row is tapped. **When set, the inline expand affordance is replaced** — the whole row becomes the tap target and the compact chevron / "Read Details" toggle is removed (in the default layout, `expandDetails: true` still renders the always-on detail panel below the row). Supported actions: `details`, `more-info`, `navigate`, `url`, `toggle`, `call-service` (alias `perform-action`), `fire-dom-event`, `none` (`assist` is intentionally unsupported — it has no meaning on an alert row; `none` is an inert chip: the toggle is removed but tapping does nothing). For `more-info`/`toggle`, the default entity is resolved **per tapped alert** — `tap_action.entity` (explicit) → the alert's own source sensor → `entity` — so per-alert providers (CAP Alerts, NSW RFS) open *that* alert's sensor while aggregate providers (NWS, DWD, …) fall back to the aggregate sensor. `toggle` uses the generic `homeassistant.toggle` service. `details` is card-owned rather than a standard HA action: it opens the tapped alert in a modal showing the whole alert body (per-alert for every provider, no add-ons — see [Themes](#themes) for an example). Absent = today's inline expand/toggle behavior, unchanged. |
 
 <details>
 <summary><strong>Examples</strong></summary>

--- a/src/styles.ts
+++ b/src/styles.ts
@@ -318,17 +318,12 @@ export const cardStyles = css`
     overflow: hidden;
   }
 
-  /* Compact expanded headline + area-desc get consistent inner padding. The
-     detail pop-up renders the same .alert-expanded body outside the compact
-     card, so it takes the identical padding (12px, matching the badges-row
-     below it) rather than a second set of values. */
-  .compact .alert-expanded .alert-headline,
-  .detail-dialog-body .alert-expanded .alert-headline {
+  /* Compact expanded headline + area-desc get consistent inner padding */
+  .compact .alert-expanded .alert-headline {
     padding: 4px 12px 0;
     margin-bottom: 2px;
   }
-  .compact .alert-expanded .area-desc,
-  .detail-dialog-body .alert-expanded .area-desc {
+  .compact .alert-expanded .area-desc {
     padding: 4px 12px 0;
     margin-bottom: 4px;
   }
@@ -1010,41 +1005,37 @@ export const cardStyles = css`
      and its inner row re-uses .alert-card for the latter — the row chrome is
      then stripped below, because inside a dialog the alert *is* the surface.
      Only the severity spine survives, as the one carry-over cue. */
-  ha-dialog {
-    --mdc-dialog-min-width: min(340px, 90vw);
-    --mdc-dialog-max-width: min(560px, 92vw);
-    --mdc-dialog-max-height: 86vh;
-    /* The expanded body brings its own inner padding (badges-row, progress
-       section, details content); the dialog must not add a second frame. */
-    --dialog-content-padding: 0;
-  }
-
-  .detail-dialog-heading {
-    display: flex;
-    align-items: center;
-    gap: 8px;
-    padding: 12px 12px 12px 20px;
-    border-bottom: 1px solid var(--divider-color);
-  }
-  .detail-dialog-title {
-    flex: 1;
-    min-width: 0;
-    font-size: 1.25rem;
-    font-weight: 500;
-    line-height: 1.3;
+  /* A NATIVE <dialog>, not <ha-dialog>: HA changed that element's API
+     incompatibly in 2026.02 and the card spans both sides of the split. See
+     the comment on _renderDetailPopup. showModal() supplies the scrim, focus
+     trap and Esc, so only the surface is styled here. */
+  dialog.detail-dialog {
+    width: min(560px, 92vw);
+    max-width: min(560px, 92vw);
+    max-height: 86vh;
+    padding: 0;
+    border: none;
+    border-radius: var(--ha-card-border-radius, 12px);
+    background: var(--ha-card-background, var(--card-background-color, #fff));
     color: var(--primary-text-color);
-    /* Event names are unbounded ("Special Marine Warning") — wrap rather than
-       widen the dialog past --mdc-dialog-max-width. */
-    overflow-wrap: anywhere;
+    box-shadow: 0 8px 32px rgba(0, 0, 0, 0.35);
+    overflow: hidden;
   }
+  dialog.detail-dialog::backdrop {
+    background: rgba(0, 0, 0, 0.55);
+  }
+  /* Sits in the alert header row where the dismiss button sits on a real row,
+     so it inherits that slot's alignment. A touch larger than .dismiss-button:
+     this is the modal's only pointer affordance besides the scrim. */
   .detail-dialog-close {
     flex: none;
     display: inline-flex;
     align-items: center;
     justify-content: center;
-    width: 36px;
-    height: 36px;
+    width: calc(32px * var(--wac-scale, 1));
+    height: calc(32px * var(--wac-scale, 1));
     padding: 0;
+    margin: 0;
     border: none;
     border-radius: 50%;
     background: transparent;
@@ -1059,13 +1050,14 @@ export const cardStyles = css`
     outline-offset: 2px;
   }
   .detail-dialog-close ha-icon {
-    --mdc-icon-size: 20px;
+    --mdc-icon-size: calc(20px * var(--wac-scale, 1));
   }
 
   /* A long description scrolls inside the dialog, never the dashboard behind
-     it (overscroll-behavior stops the scroll chaining at the edge). */
+     it (overscroll-behavior stops the scroll chaining at the edge). Matches the
+     dialog's own max-height, which has no padding of its own. */
   .detail-dialog-body {
-    max-height: min(70vh, 720px);
+    max-height: 86vh;
     overflow-y: auto;
     overscroll-behavior: contain;
   }
@@ -1077,9 +1069,6 @@ export const cardStyles = css`
     /* No pulse-border for extreme/severe: a modal already has the user's full
        attention, and a pulsing frame around it only competes with the text. */
     animation: none;
-  }
-  .detail-dialog-body .alert-expanded {
-    padding-top: 8px;
   }
 
   /* --- EMPTY STATE --- */

--- a/src/styles.ts
+++ b/src/styles.ts
@@ -318,12 +318,17 @@ export const cardStyles = css`
     overflow: hidden;
   }
 
-  /* Compact expanded headline + area-desc get consistent inner padding */
-  .compact .alert-expanded .alert-headline {
+  /* Compact expanded headline + area-desc get consistent inner padding. The
+     detail pop-up renders the same .alert-expanded body outside the compact
+     card, so it takes the identical padding (12px, matching the badges-row
+     below it) rather than a second set of values. */
+  .compact .alert-expanded .alert-headline,
+  .detail-dialog-body .alert-expanded .alert-headline {
     padding: 4px 12px 0;
     margin-bottom: 2px;
   }
-  .compact .alert-expanded .area-desc {
+  .compact .alert-expanded .area-desc,
+  .detail-dialog-body .alert-expanded .area-desc {
     padding: 4px 12px 0;
     margin-bottom: 4px;
   }
@@ -996,6 +1001,85 @@ export const cardStyles = css`
     color: var(--secondary-text-color);
     padding: 8px 16px 0;
     opacity: 0.7;
+  }
+
+  /* --- PER-ALERT DETAIL POP-UP (tap_action: { action: details }) --- */
+  /* The dialog renders as a sibling of <ha-card>, outside the context that
+     normally supplies the per-row tokens (data-theme-mode on the card root,
+     --color/--wac-fg on .alert-card). So .detail-dialog-body carries the former
+     and its inner row re-uses .alert-card for the latter — the row chrome is
+     then stripped below, because inside a dialog the alert *is* the surface.
+     Only the severity spine survives, as the one carry-over cue. */
+  ha-dialog {
+    --mdc-dialog-min-width: min(340px, 90vw);
+    --mdc-dialog-max-width: min(560px, 92vw);
+    --mdc-dialog-max-height: 86vh;
+    /* The expanded body brings its own inner padding (badges-row, progress
+       section, details content); the dialog must not add a second frame. */
+    --dialog-content-padding: 0;
+  }
+
+  .detail-dialog-heading {
+    display: flex;
+    align-items: center;
+    gap: 8px;
+    padding: 12px 12px 12px 20px;
+    border-bottom: 1px solid var(--divider-color);
+  }
+  .detail-dialog-title {
+    flex: 1;
+    min-width: 0;
+    font-size: 1.25rem;
+    font-weight: 500;
+    line-height: 1.3;
+    color: var(--primary-text-color);
+    /* Event names are unbounded ("Special Marine Warning") — wrap rather than
+       widen the dialog past --mdc-dialog-max-width. */
+    overflow-wrap: anywhere;
+  }
+  .detail-dialog-close {
+    flex: none;
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    width: 36px;
+    height: 36px;
+    padding: 0;
+    border: none;
+    border-radius: 50%;
+    background: transparent;
+    color: var(--secondary-text-color);
+    cursor: pointer;
+  }
+  .detail-dialog-close:hover {
+    background: var(--secondary-background-color);
+  }
+  .detail-dialog-close:focus-visible {
+    outline: 2px solid var(--wac-focus-ring, var(--primary-color));
+    outline-offset: 2px;
+  }
+  .detail-dialog-close ha-icon {
+    --mdc-icon-size: 20px;
+  }
+
+  /* A long description scrolls inside the dialog, never the dashboard behind
+     it (overscroll-behavior stops the scroll chaining at the edge). */
+  .detail-dialog-body {
+    max-height: min(70vh, 720px);
+    overflow-y: auto;
+    overscroll-behavior: contain;
+  }
+  .detail-dialog-body .alert-card {
+    margin-bottom: 0;
+    border: none;
+    border-radius: 0;
+    box-shadow: none;
+    /* No pulse-border for extreme/severe: a modal already has the user's full
+       attention, and a pulsing frame around it only competes with the text. */
+    animation: none;
+  }
+  .detail-dialog-body .alert-expanded {
+    padding-top: 8px;
   }
 
   /* --- EMPTY STATE --- */

--- a/src/translations/de.ts
+++ b/src/translations/de.ts
@@ -14,6 +14,7 @@ export const de: TranslationMap = {
   'card.dismiss': 'Ausblenden',
   'card.dismissed_toast': 'Ausgeblendet: {event}',
   'card.dismissed_toast_undo': 'Rückgängig',
+  'card.close': 'Schließen',
 
   // Detail labels
   'detail.issued': 'Ausgegeben',

--- a/src/translations/en.ts
+++ b/src/translations/en.ts
@@ -14,6 +14,7 @@ export const en: TranslationMap = {
   'card.dismiss': 'Dismiss',
   'card.dismissed_toast': 'Dismissed: {event}',
   'card.dismissed_toast_undo': 'Undo',
+  'card.close': 'Close',
 
   // Detail labels
   'detail.issued': 'Issued',

--- a/src/translations/es.ts
+++ b/src/translations/es.ts
@@ -14,6 +14,7 @@ export const es: TranslationMap = {
   'card.dismiss': 'Descartar',
   'card.dismissed_toast': 'Descartada: {event}',
   'card.dismissed_toast_undo': 'Deshacer',
+  'card.close': 'Cerrar',
 
   // Detail labels
   'detail.issued': 'Emitido',

--- a/src/translations/fr.ts
+++ b/src/translations/fr.ts
@@ -14,6 +14,7 @@ export const fr: TranslationMap = {
   'card.dismiss': 'Ignorer',
   'card.dismissed_toast': 'Ignorée : {event}',
   'card.dismissed_toast_undo': 'Annuler',
+  'card.close': 'Fermer',
 
   // Detail labels
   'detail.issued': 'Emis',

--- a/src/translations/it.ts
+++ b/src/translations/it.ts
@@ -14,6 +14,7 @@ export const it: TranslationMap = {
   'card.dismiss': 'Ignora',
   'card.dismissed_toast': 'Ignorata: {event}',
   'card.dismissed_toast_undo': 'Annulla',
+  'card.close': 'Chiudi',
 
   // Detail labels
   'detail.issued': 'Emessa',

--- a/src/types.ts
+++ b/src/types.ts
@@ -43,6 +43,10 @@ export interface ActionConfig {
     | 'call-service'
     | 'perform-action'
     | 'fire-dom-event'
+    // Card-owned, NOT a standard HA action: opens the tapped alert's
+    // expanded-details view in a modal dialog. Never reaches handleTapAction —
+    // the card intercepts it in _onCardAction (see plans/per-alert-detail-popup.md).
+    | 'details'
     | 'none';
   entity?: string;
   navigation_path?: string;

--- a/src/weather-alerts-card.ts
+++ b/src/weather-alerts-card.ts
@@ -190,6 +190,8 @@ export class WeatherAlertsCard extends LitElement {
   @state() private _config!: WeatherAlertsCardConfig;
   @state() private _expandedAlerts: Map<string, boolean> = new Map();
   @state() private _forcePreview = false;
+  /** Alert id whose detail pop-up is open (`tap_action: { action: details }`); null when closed. */
+  @state() private _detailPopupAlertId: string | null = null;
   @state() private _dismissals: Map<string, DismissalRecord> = new Map();
   private _dismissalsScope = '';
   private _unsubscribeDismissals?: () => void;
@@ -268,6 +270,13 @@ export class WeatherAlertsCard extends LitElement {
     if ((changed.has('hass') || changed.has('_config')) && this.isConnected) {
       this._maybeSubscribeRegistry();
       this._maybeFetchGeometry();
+    }
+    // Auto-close the detail pop-up when its alert churns out of the feed (or
+    // the card drops to preview / hides itself). render() stays side-effect
+    // free, so it just renders nothing for an unresolvable id; the stale id is
+    // reconciled here, once, after the dialog is gone from the tree.
+    if (this._detailPopupAlertId && !this.shadowRoot?.querySelector('ha-dialog')) {
+      this._closeDetailPopup();
     }
   }
 
@@ -943,7 +952,27 @@ export class WeatherAlertsCard extends LitElement {
     }
     const cfg = this._config?.tap_action;
     if (!cfg || cfg.action === 'none') return;
+    // 'details' is card-owned: opening the pop-up needs card state and the
+    // in-hand alert object, so it is intercepted here rather than added to the
+    // deliberately dependency-free dispatcher (plans/per-alert-detail-popup.md, D3).
+    if (cfg.action === 'details') {
+      this._openDetailPopup(alert);
+      return;
+    }
     handleTapAction(this, this.hass, cfg, alert.sourceEntityId ?? this._config?.entity);
+  }
+
+  // The pop-up alternative to the inline expand: shows only the tapped alert's
+  // expanded-details view. Scoped by the in-hand alert object rather than by a
+  // re-query, so it is per-alert for aggregate providers (one sensor holding
+  // many alerts) exactly as it is for per-alert-entity ones.
+  // Reached only via _onCardAction, which has already swallowed a post-swipe click.
+  private _openDetailPopup(alert: WeatherAlert): void {
+    this._detailPopupAlertId = alert.id;
+  }
+
+  private _closeDetailPopup(): void {
+    this._detailPopupAlertId = null;
   }
 
   private _onCardActionKeydown(alert: WeatherAlert, e: KeyboardEvent): void {
@@ -1125,6 +1154,76 @@ export class WeatherAlertsCard extends LitElement {
         ? alerts.map(alert => this._renderAlert(alert))
         : this._renderNoAlerts(signalAvailability ? brokenSources : [])}
       </ha-card>
+      ${this._renderDetailPopup(alerts)}
+    `;
+  }
+
+  // Card-owned per-alert detail pop-up (tap_action: { action: details }) — the
+  // modal alternative to the inline expand. The body re-renders the same
+  // expanded content the inline expand shows, so showDetails / showMetadata /
+  // showGeometry / expandDetails all still govern it.
+  //
+  // Scoping is by the in-hand alert object, never a re-query, which is what
+  // makes it per-alert for aggregate providers (one sensor holding many alerts)
+  // exactly as it is for per-alert-entity ones.
+  //
+  // ha-dialog is an HA-internal element, but it ships with the frontend (so no
+  // bundle cost) and brings focus-trap, Esc, scrim, aria-modal and focus
+  // restoration for free. Only `open`, `.heading` and the `closed` event are
+  // consumed — its most stable surface (plans/per-alert-detail-popup.md, R2).
+  private _renderDetailPopup(alerts: WeatherAlert[]): TemplateResult | typeof nothing {
+    if (!this._detailPopupAlertId) return nothing;
+    // Re-resolved every render: a live feed can drop the open alert, in which
+    // case nothing renders and updated() clears the stale id.
+    const alert = alerts.find(a => a.id === this._detailPopupAlertId);
+    if (!alert) return nothing;
+
+    const progress = computeAlertProgress(alert);
+    const isOngoing = progress.isActive && !progress.hasEndTime;
+    // The inner row re-uses .alert-card only for its token block (--color,
+    // --wac-fg, --wac-progress-fg); styles.ts strips the row chrome. Mirrors
+    // _renderFullAlert's class/style computation minus the row-only concerns
+    // (swipe, tappable) and progressFill:background — the whole-row wash is a
+    // row treatment, so the dialog always shows the ordinary progress track.
+    const rowClasses = [
+      'alert-card',
+      `severity-${alert.severity}`,
+      progress.phaseText.toLowerCase(),
+      isOngoing ? 'ongoing' : '',
+      this._alertDecoClasses(progress),
+      this._alertBoostClasses(alert),
+    ].filter(Boolean).join(' ');
+    const rowStyle = `${this._alertColorStyle(alert)} --progress: ${isOngoing ? 0 : progress.progressPct}%;`;
+    const closeLabel = t('card.close', this._lang);
+
+    return html`
+      <ha-dialog
+        open
+        .heading=${alert.event}
+        @closed=${() => this._closeDetailPopup()}
+      >
+        <div class="detail-dialog-heading" slot="heading">
+          <span class="detail-dialog-title" title=${alert.event}>${alert.event}</span>
+          <button
+            type="button"
+            class="detail-dialog-close"
+            aria-label=${closeLabel}
+            title=${closeLabel}
+            @click=${() => this._closeDetailPopup()}
+          >
+            <ha-icon icon="mdi:close"></ha-icon>
+          </button>
+        </div>
+        <div
+          class="detail-dialog-body ${this._animationsEnabled ? '' : 'no-animations'}"
+          data-theme-mode=${this._themeMode}
+          style=${this._scaleStyle}
+        >
+          <div class=${rowClasses} style=${rowStyle}>
+            ${this._renderExpandedContent(alert, progress)}
+          </div>
+        </div>
+      </ha-dialog>
     `;
   }
 

--- a/src/weather-alerts-card.ts
+++ b/src/weather-alerts-card.ts
@@ -271,12 +271,21 @@ export class WeatherAlertsCard extends LitElement {
       this._maybeSubscribeRegistry();
       this._maybeFetchGeometry();
     }
-    // Auto-close the detail pop-up when its alert churns out of the feed (or
-    // the card drops to preview / hides itself). render() stays side-effect
-    // free, so it just renders nothing for an unresolvable id; the stale id is
-    // reconciled here, once, after the dialog is gone from the tree.
-    if (this._detailPopupAlertId && !this.shadowRoot?.querySelector('ha-dialog')) {
+    // The detail pop-up is reconciled after render, never during it, so
+    // render() stays side-effect free:
+    //   - alert churned out of the feed (or the card dropped to preview /
+    //     hid itself): nothing rendered for the id, so clear the stale id.
+    //   - freshly rendered: promote it to a modal. showModal() is what buys
+    //     the focus trap, Esc and ::backdrop; a plain `open` attribute would
+    //     render the box non-modally with none of that.
+    const dialog = this._detailPopupEl;
+    if (this._detailPopupAlertId && !dialog) {
       this._closeDetailPopup();
+    } else if (dialog && !dialog.open) {
+      // jsdom implements <dialog> but has historically shipped without
+      // showModal; degrade to a non-modal open rather than throwing in tests.
+      if (typeof dialog.showModal === 'function') dialog.showModal();
+      else dialog.setAttribute('open', '');
     }
   }
 
@@ -1167,10 +1176,14 @@ export class WeatherAlertsCard extends LitElement {
   // makes it per-alert for aggregate providers (one sensor holding many alerts)
   // exactly as it is for per-alert-entity ones.
   //
-  // ha-dialog is an HA-internal element, but it ships with the frontend (so no
-  // bundle cost) and brings focus-trap, Esc, scrim, aria-modal and focus
-  // restoration for free. Only `open`, `.heading` and the `closed` event are
-  // consumed — its most stable surface (plans/per-alert-detail-popup.md, R2).
+  // Deliberately a NATIVE <dialog>, not <ha-dialog>. ha-dialog's API changed
+  // incompatibly in HA 2026.02 (mwc `heading` + slot="heading" → WebAwesome
+  // `header-title` / headerTitle / headerNavigationIcon slots), and the card
+  // supports HA versions on both sides of that line — one template cannot serve
+  // both, and an unassigned slot renders nothing at all rather than failing
+  // loudly. showModal() gives focus trap, Esc, ::backdrop and aria-modal from
+  // the platform, so nothing here is hand-rolled a11y and nothing tracks HA's
+  // component churn. (plans/per-alert-detail-popup.md R2, fallback D4(b).)
   private _renderDetailPopup(alerts: WeatherAlert[]): TemplateResult | typeof nothing {
     if (!this._detailPopupAlertId) return nothing;
     // Re-resolved every render: a live feed can drop the open alert, in which
@@ -1194,37 +1207,60 @@ export class WeatherAlertsCard extends LitElement {
       this._alertBoostClasses(alert),
     ].filter(Boolean).join(' ');
     const rowStyle = `${this._alertColorStyle(alert)} --progress: ${isOngoing ? 0 : progress.progressPct}%;`;
-    const closeLabel = t('card.close', this._lang);
 
     return html`
-      <ha-dialog
-        open
-        .heading=${alert.event}
-        @closed=${() => this._closeDetailPopup()}
+      <dialog
+        class="detail-dialog"
+        aria-label=${alert.event}
+        @close=${() => this._closeDetailPopup()}
+        @click=${this._onDetailPopupClick}
       >
-        <div class="detail-dialog-heading" slot="heading">
-          <span class="detail-dialog-title" title=${alert.event}>${alert.event}</span>
-          <button
-            type="button"
-            class="detail-dialog-close"
-            aria-label=${closeLabel}
-            title=${closeLabel}
-            @click=${() => this._closeDetailPopup()}
-          >
-            <ha-icon icon="mdi:close"></ha-icon>
-          </button>
-        </div>
         <div
           class="detail-dialog-body ${this._animationsEnabled ? '' : 'no-animations'}"
           data-theme-mode=${this._themeMode}
           style=${this._scaleStyle}
         >
           <div class=${rowClasses} style=${rowStyle}>
-            ${this._renderExpandedContent(alert, progress)}
+            ${this._renderAlertBody(alert, progress, { expanded: true, inPopup: true })}
           </div>
         </div>
-      </ha-dialog>
+      </dialog>
     `;
+  }
+
+  // A click whose target is the <dialog> itself landed on the ::backdrop —
+  // the content sits in child elements, so it can only be the scrim.
+  private _onDetailPopupClick(e: Event): void {
+    if (e.target === e.currentTarget) this._dismissDetailPopup(e.currentTarget as HTMLDialogElement);
+  }
+
+  // close() fires the dialog's `close` event, so Esc, the scrim and the close
+  // button all converge on the same single state-clearing path. jsdom ships
+  // <dialog> without close()/showModal(), so degrade to clearing state
+  // directly there rather than throwing.
+  private _dismissDetailPopup(dialog?: HTMLDialogElement | null): void {
+    const el = dialog ?? this._detailPopupEl;
+    if (el && typeof el.close === 'function') el.close();
+    else this._closeDetailPopup();
+  }
+
+  private _renderDetailPopupClose(): TemplateResult {
+    const label = t('card.close', this._lang);
+    return html`
+      <button
+        type="button"
+        class="detail-dialog-close"
+        aria-label=${label}
+        title=${label}
+        @click=${() => this._dismissDetailPopup()}
+      >
+        <ha-icon icon="mdi:close"></ha-icon>
+      </button>
+    `;
+  }
+
+  private get _detailPopupEl(): HTMLDialogElement | null {
+    return this.shadowRoot?.querySelector<HTMLDialogElement>('dialog.detail-dialog') ?? null;
   }
 
   private _renderPreview(): TemplateResult {
@@ -1395,53 +1431,74 @@ export class WeatherAlertsCard extends LitElement {
         @click=${actionable ? () => this._onCardAction(alert) : nothing}
         @keydown=${actionable ? (e: KeyboardEvent) => this._onCardActionKeydown(alert, e) : nothing}
       >
-        <div class="alert-header-row">
-          <div class="icon-box">
-            <ha-icon icon=${alert.providerIcon ?? getWeatherIcon(alert.iconHint || alert.event)}></ha-icon>
-          </div>
-          <div class="info-box">
-            <div class="title-row">
-              ${this._renderProviderHint(alert)}
-              <span class="alert-title">${alert.event}</span>
-            </div>
-            ${this._renderHeadline(alert)}
-            ${alert.areaDesc ? html`
-              <div class="area-desc" title=${alert.areaDesc}>
-                <ha-icon icon="mdi:map-marker"></ha-icon>
-                <span class="area-desc-text">${alert.areaDesc}</span>
-              </div>
-            ` : nothing}
-            <div class="badges-row">
-              ${this._renderBadgesRow(alert, progress)}
-            </div>
-          </div>
-          ${this._renderDismissButton(alert)}
+        ${this._renderAlertBody(alert, progress, { expanded, inPopup: false })}
+      </div>
+    `;
+  }
+
+  // The full alert body — header row (icon, provider hint, title, headline,
+  // area, badges), progress section, details. Shared verbatim by the
+  // default-layout row and the detail pop-up so the two cannot drift; the row
+  // wrapper (swipe/tap/severity classes) stays with each caller.
+  private _renderAlertBody(
+    alert: WeatherAlert, progress: AlertProgress,
+    opts: { expanded: boolean; inPopup: boolean },
+  ): TemplateResult {
+    const tapAction = hasTapAction(this._config);
+    const showDetails = this._config?.showDetails !== false;
+    return html`
+      <div class="alert-header-row">
+        <div class="icon-box">
+          <ha-icon icon=${alert.providerIcon ?? getWeatherIcon(alert.iconHint || alert.event)}></ha-icon>
         </div>
+        <div class="info-box">
+          <div class="title-row">
+            ${this._renderProviderHint(alert)}
+            <span class="alert-title">${alert.event}</span>
+          </div>
+          ${this._renderHeadline(alert)}
+          ${alert.areaDesc ? html`
+            <div class="area-desc" title=${alert.areaDesc}>
+              <ha-icon icon="mdi:map-marker"></ha-icon>
+              <span class="area-desc-text">${alert.areaDesc}</span>
+            </div>
+          ` : nothing}
+          <div class="badges-row">
+            ${this._renderBadgesRow(alert, progress)}
+          </div>
+        </div>
+        ${opts.inPopup ? this._renderDetailPopupClose() : this._renderDismissButton(alert)}
+      </div>
 
-        ${this._renderProgressSection(alert, progress)}
+      ${this._renderProgressSection(alert, progress)}
 
-        ${tapAction
-          ? (this._config?.showDetails !== false && this._config?.expandDetails
+      ${opts.inPopup
+        // The pop-up *is* the details view, so it never gates its own content
+        // behind a second toggle: showDetails still suppresses the panel, but
+        // expandDetails governs the row only. Opening a detail pop-up and
+        // having to click "Read Details" inside it was the rough edge here.
+        ? (showDetails ? this._renderDetailsContent(alert, progress) : nothing)
+        : (tapAction
+          ? (showDetails && this._config?.expandDetails
             ? this._renderDetailsContent(alert, progress)
             : nothing)
-          : (this._config?.showDetails !== false ? (this._config?.expandDetails ? html`
-        ${this._renderDetailsContent(alert, progress)}
-        ` : html`
-        <div class="alert-details-section">
-          <div
-            class="details-summary"
-            @click=${() => this._toggleDetails(alert.id)}
-          >
-            <span>${t('card.read_details', this._lang)}</span>
-            <ha-icon
-              icon="mdi:chevron-down"
-              class="chevron ${expanded ? 'expanded' : ''}"
-            ></ha-icon>
-          </div>
-          ${expanded ? this._renderDetailsContent(alert, progress) : nothing}
+          : (showDetails ? (this._config?.expandDetails ? html`
+      ${this._renderDetailsContent(alert, progress)}
+      ` : html`
+      <div class="alert-details-section">
+        <div
+          class="details-summary"
+          @click=${() => this._toggleDetails(alert.id)}
+        >
+          <span>${t('card.read_details', this._lang)}</span>
+          <ha-icon
+            icon="mdi:chevron-down"
+            class="chevron ${opts.expanded ? 'expanded' : ''}"
+          ></ha-icon>
         </div>
-        `) : nothing)}
+        ${opts.expanded ? this._renderDetailsContent(alert, progress) : nothing}
       </div>
+      `) : nothing))}
     `;
   }
 

--- a/tests/card-tap-action.test.ts
+++ b/tests/card-tap-action.test.ts
@@ -32,6 +32,7 @@ interface CardInternals {
   shadowRoot: ShadowRoot | null;
   remove(): void;
   _swipeJustDragged: boolean;
+  _detailPopupAlertId: string | null;
 }
 
 // One aggregate NWS sensor — every parsed alert's sourceEntityId is this sensor.
@@ -55,6 +56,40 @@ function nwsHass(): HomeAssistant {
             URL: 'https://example.test/wind',
             Headline: '',
           }],
+        },
+      },
+    },
+    locale: { language: 'en' },
+  } as unknown as HomeAssistant;
+}
+
+// One aggregate NWS sensor holding TWO alerts. The decisive fixture for
+// action:details — per-alert scoping here cannot come from entity granularity,
+// because both alerts share a single source entity.
+function nwsTwoAlertHass(): HomeAssistant {
+  const now = Date.now();
+  const alert = (id: string, event: string, description: string) => ({
+    ID: id,
+    Event: event,
+    Severity: 'Severe',
+    Sent: new Date(now - 2 * HOUR).toISOString(),
+    Onset: new Date(now - 1 * HOUR).toISOString(),
+    Ends: new Date(now + 3 * HOUR).toISOString(),
+    Expires: new Date(now + 3 * HOUR).toISOString(),
+    Description: description,
+    Instruction: '',
+    URL: '',
+    Headline: '',
+  });
+  return {
+    states: {
+      'sensor.nws_alerts': {
+        state: '2',
+        attributes: {
+          Alerts: [
+            alert('wind-severe', 'High Wind Warning', 'Damaging winds.'),
+            alert('flood-severe', 'Flash Flood Warning', 'Rapid rises expected.'),
+          ],
         },
       },
     },
@@ -424,6 +459,171 @@ describe('dismiss button', () => {
     expect(btn).not.toBeNull();
     btn!.click();
     expect(seen).toEqual([]);
+    cleanup();
+  });
+});
+
+describe('tap_action action:details', () => {
+  const settle = (card: CardInternals) =>
+    (card as unknown as { updateComplete: Promise<void> }).updateComplete;
+
+  const dialog = (card: CardInternals) => root(card).querySelector<HTMLElement>('ha-dialog');
+
+  // expandDetails keeps the description panel open inside the dialog, so the
+  // assertions can read the alert's own text rather than a collapsed toggle.
+  const detailsConfig = (extra: Partial<WeatherAlertsCardConfig> = {}) =>
+    baseFull({ tap_action: { action: 'details' }, expandDetails: true, ...extra });
+
+  it('opens a dialog carrying only the tapped alert (full layout)', async () => {
+    const { card, cleanup } = await mountCard(detailsConfig(), nwsHass());
+    expect(dialog(card)).toBeNull();
+
+    root(card).querySelector<HTMLElement>('.alert-card')!.click();
+    await settle(card);
+
+    expect(card._detailPopupAlertId).toBe('wind-severe');
+    const d = dialog(card)!;
+    expect(d).not.toBeNull();
+    expect(root(card).querySelector('.detail-dialog-title')!.textContent!.trim())
+      .toBe('High Wind Warning');
+    expect(d.querySelector('.alert-expanded')).not.toBeNull();
+    expect(d.textContent).toContain('Damaging winds.');
+    cleanup();
+  });
+
+  it('opens the dialog from the compact layout too', async () => {
+    const { card, cleanup } = await mountCard(
+      detailsConfig({ layout: 'compact' }), nwsHass(),
+    );
+    // Presence of tap_action still removes the inline expand affordance.
+    expect(root(card).querySelector('.compact-chevron')).toBeNull();
+
+    root(card).querySelector<HTMLElement>('.compact-row')!.click();
+    await settle(card);
+
+    expect(card._detailPopupAlertId).toBe('wind-severe');
+    expect(dialog(card)).not.toBeNull();
+    cleanup();
+  });
+
+  // The decisive case: one aggregate sensor, two alerts. Scoping comes from the
+  // in-hand alert object, not from per-alert entities.
+  it('scopes to the tapped alert on an aggregate sensor holding two alerts', async () => {
+    const { card, cleanup } = await mountCard(detailsConfig(), nwsTwoAlertHass());
+    const rows = root(card).querySelectorAll<HTMLElement>('.alert-card');
+    expect(rows.length).toBe(2);
+
+    rows[1].click();
+    await settle(card);
+
+    expect(card._detailPopupAlertId).toBe('flood-severe');
+    const d = dialog(card)!;
+    expect(root(card).querySelector('.detail-dialog-title')!.textContent!.trim())
+      .toBe('Flash Flood Warning');
+    expect(d.textContent).toContain('Rapid rises expected.');
+    expect(d.textContent).not.toContain('Damaging winds.');
+
+    // Re-tapping the first row swaps the dialog over to it, not adds a second.
+    rows[0].click();
+    await settle(card);
+    expect(card._detailPopupAlertId).toBe('wind-severe');
+    expect(root(card).querySelectorAll('ha-dialog').length).toBe(1);
+    expect(dialog(card)!.textContent).toContain('Damaging winds.');
+    cleanup();
+  });
+
+  it('the close button clears the state and removes the dialog', async () => {
+    const { card, cleanup } = await mountCard(detailsConfig(), nwsHass());
+    root(card).querySelector<HTMLElement>('.alert-card')!.click();
+    await settle(card);
+
+    root(card).querySelector<HTMLElement>('.detail-dialog-close')!.click();
+    await settle(card);
+
+    expect(card._detailPopupAlertId).toBeNull();
+    expect(dialog(card)).toBeNull();
+    cleanup();
+  });
+
+  // Esc and the scrim both surface as ha-dialog's `closed` event — the only
+  // dialog-internal contract the card consumes.
+  it('ha-dialog closed (Esc / scrim) clears the state', async () => {
+    const { card, cleanup } = await mountCard(detailsConfig(), nwsHass());
+    root(card).querySelector<HTMLElement>('.alert-card')!.click();
+    await settle(card);
+
+    dialog(card)!.dispatchEvent(new CustomEvent('closed', { detail: { action: 'close' } }));
+    await settle(card);
+
+    expect(card._detailPopupAlertId).toBeNull();
+    expect(dialog(card)).toBeNull();
+    cleanup();
+  });
+
+  it('Enter and Space open the dialog from the keyboard', async () => {
+    for (const key of ['Enter', ' ']) {
+      const { card, cleanup } = await mountCard(detailsConfig(), nwsHass());
+      root(card).querySelector<HTMLElement>('.alert-card')!
+        .dispatchEvent(new KeyboardEvent('keydown', { key, bubbles: true }));
+      await settle(card);
+
+      expect(card._detailPopupAlertId, key).toBe('wind-severe');
+      expect(dialog(card), key).not.toBeNull();
+      cleanup();
+    }
+  });
+
+  it('fires no HA action — the dispatcher is never reached', async () => {
+    const { card, cleanup } = await mountCard(detailsConfig(), nwsHass());
+    const seen: string[] = [];
+    const onMoreInfo = () => seen.push('more-info');
+    const onCustom = () => seen.push('ll-custom');
+    const onNav = () => seen.push('location-changed');
+    window.addEventListener('hass-more-info', onMoreInfo);
+    window.addEventListener('ll-custom', onCustom);
+    window.addEventListener('location-changed', onNav);
+
+    root(card).querySelector<HTMLElement>('.alert-card')!.click();
+    await settle(card);
+
+    expect(seen).toEqual([]);
+    expect(card._detailPopupAlertId).toBe('wind-severe');
+
+    window.removeEventListener('hass-more-info', onMoreInfo);
+    window.removeEventListener('ll-custom', onCustom);
+    window.removeEventListener('location-changed', onNav);
+    cleanup();
+  });
+
+  it('a click synthesized after a swipe drag does not open it', async () => {
+    const { card, cleanup } = await mountCard(detailsConfig(), nwsHass());
+    card._swipeJustDragged = true;
+    root(card).querySelector<HTMLElement>('.alert-card')!.click();
+    await settle(card);
+
+    expect(card._detailPopupAlertId).toBeNull();
+    expect(dialog(card)).toBeNull();
+    expect(card._swipeJustDragged).toBe(false);
+
+    // The next genuine click still opens it.
+    root(card).querySelector<HTMLElement>('.alert-card')!.click();
+    await settle(card);
+    expect(card._detailPopupAlertId).toBe('wind-severe');
+    cleanup();
+  });
+
+  it('auto-closes when the open alert churns out of the feed', async () => {
+    const { card, cleanup } = await mountCard(detailsConfig(), nwsTwoAlertHass());
+    root(card).querySelectorAll<HTMLElement>('.alert-card')[1].click();
+    await settle(card);
+    expect(card._detailPopupAlertId).toBe('flood-severe');
+
+    // The feed drops the open alert; the remaining one must not inherit the dialog.
+    card.hass = nwsHass();
+    await settle(card);
+
+    expect(dialog(card)).toBeNull();
+    expect(card._detailPopupAlertId).toBeNull();
     cleanup();
   });
 });

--- a/tests/card-tap-action.test.ts
+++ b/tests/card-tap-action.test.ts
@@ -467,7 +467,7 @@ describe('tap_action action:details', () => {
   const settle = (card: CardInternals) =>
     (card as unknown as { updateComplete: Promise<void> }).updateComplete;
 
-  const dialog = (card: CardInternals) => root(card).querySelector<HTMLElement>('ha-dialog');
+  const dialog = (card: CardInternals) => root(card).querySelector<HTMLDialogElement>('dialog.detail-dialog');
 
   // expandDetails keeps the description panel open inside the dialog, so the
   // assertions can read the alert's own text rather than a collapsed toggle.
@@ -484,9 +484,13 @@ describe('tap_action action:details', () => {
     expect(card._detailPopupAlertId).toBe('wind-severe');
     const d = dialog(card)!;
     expect(d).not.toBeNull();
-    expect(root(card).querySelector('.detail-dialog-title')!.textContent!.trim())
+    // The whole alert body renders inside, so the alert's own title is on
+    // screen (the reason the expanded-sub-block-only version was wrong).
+    expect(d.querySelector('.alert-title')!.textContent!.trim())
       .toBe('High Wind Warning');
-    expect(d.querySelector('.alert-expanded')).not.toBeNull();
+    expect(d.querySelector('.alert-header-row')).not.toBeNull();
+    expect(d.querySelector('.icon-box')).not.toBeNull();
+    expect(d.querySelector('.progress-section')).not.toBeNull();
     expect(d.textContent).toContain('Damaging winds.');
     cleanup();
   });
@@ -518,7 +522,7 @@ describe('tap_action action:details', () => {
 
     expect(card._detailPopupAlertId).toBe('flood-severe');
     const d = dialog(card)!;
-    expect(root(card).querySelector('.detail-dialog-title')!.textContent!.trim())
+    expect(d.querySelector('.alert-title')!.textContent!.trim())
       .toBe('Flash Flood Warning');
     expect(d.textContent).toContain('Rapid rises expected.');
     expect(d.textContent).not.toContain('Damaging winds.');
@@ -527,7 +531,7 @@ describe('tap_action action:details', () => {
     rows[0].click();
     await settle(card);
     expect(card._detailPopupAlertId).toBe('wind-severe');
-    expect(root(card).querySelectorAll('ha-dialog').length).toBe(1);
+    expect(root(card).querySelectorAll('dialog.detail-dialog').length).toBe(1);
     expect(dialog(card)!.textContent).toContain('Damaging winds.');
     cleanup();
   });
@@ -545,14 +549,14 @@ describe('tap_action action:details', () => {
     cleanup();
   });
 
-  // Esc and the scrim both surface as ha-dialog's `closed` event — the only
-  // dialog-internal contract the card consumes.
-  it('ha-dialog closed (Esc / scrim) clears the state', async () => {
+  // Esc and the scrim both surface as the native dialog's `close` event, the
+  // single path through which the pop-up state is cleared.
+  it('native dialog close (Esc / scrim) clears the state', async () => {
     const { card, cleanup } = await mountCard(detailsConfig(), nwsHass());
     root(card).querySelector<HTMLElement>('.alert-card')!.click();
     await settle(card);
 
-    dialog(card)!.dispatchEvent(new CustomEvent('closed', { detail: { action: 'close' } }));
+    dialog(card)!.dispatchEvent(new Event('close'));
     await settle(card);
 
     expect(card._detailPopupAlertId).toBeNull();


### PR DESCRIPTION
Realizes the card-owner's half of #189 that #221 deferred: `tap_action: { action: details }` opens a pop-up showing **only the tapped alert**, as the alternative to the inline expand.

```yaml
type: custom:weather-alerts-card
entity: sensor.nws_alerts_alerts
provider: nws
layout: compact
tap_action:
  action: details
```

## Why it is card-owned rather than a dispatcher case

`details` is not a standard HA action. It is intercepted in `_onCardAction` ahead of `handleTapAction` rather than added to `actions.ts`, which is deliberately dependency-free and card-agnostic — it fires only standard HA events, while opening a dialog needs card state and the alert object. The only edit to the dispatch path is a leading early-return branch; every other action flows through unchanged.

## Why it beats the existing pop-up recipes

Scoping is by the in-hand alert object, never a re-query. That is what makes it per-alert for **every** provider: an aggregate sensor holding five warnings yields five distinct pop-ups, where a Bubble hash (one static pop-up) and `more-info` (one entity) both collapse to a single shared view. The decisive test uses a two-alert NWS sensor and asserts the second row's dialog carries the second alert's text and not the first's.

Bubble Card and `browser_mod` remain available via `navigate` / `fire-dom-event`, unchanged.

## A native `<dialog>`, not `<ha-dialog>`

The first pass used `<ha-dialog>`. Live testing on HA 2026.7 showed the pop-up opening with **no title and no close button**.

`ha-dialog`'s API changed incompatibly in HA 2026.02 — mwc `heading` + `slot="heading"` became WebAwesome `header-title` / `headerTitle` / `headerNavigationIcon`. Verified against the installed frontend rather than from memory: every chunk defining `ha-dialog` carries only the new API, and `mdc-dialog__title` appears in **zero** files. So `.heading` was ignored and the `slot="heading"` subtree — title *and* close button — was never assigned, which renders as nothing rather than failing loudly.

One template cannot serve both APIs, and this card supports HA versions on either side of that line. So the pop-up is now a **native `<dialog>` + `showModal()`**: focus trap, `Esc`, `::backdrop` and `aria-modal` come from the platform, so there is no hand-rolled a11y and nothing tracking HA's component churn. This is the plan's own R2 fallback (D4(b)) — the risk it recorded as hypothetical had already materialized.

## The whole alert body

The pop-up renders the **whole alert** — icon, title, headline, area, badges, progress, metadata, description, instructions — via a `_renderAlertBody()` now shared with the default-layout row, so the two cannot drift. (The first pass reused `_renderExpandedContent`, which starts at the headline because its caller is the compact row whose header already carries the title; in a modal that meant the alert's own title never appeared.)

Consequently **the pop-up ignores `expandDetails` and always shows the description** — the pop-up *is* the detail view, so gating its content behind a "Read Details" toggle inside itself was indefensible. `expandDetails` now governs the row only; `showDetails: false` still suppresses the panel.

## Notes on the rendering

- Living outside `<ha-card>` costs the per-row token context, so `.detail-dialog-body` carries `data-theme-mode` / `--wac-scale` / `no-animations` and its inner div re-uses `.alert-card` purely for `--color`/`--wac-fg`; `styles.ts` strips the row chrome, keeping only the severity spine. `progressFill: background` is not carried across — the whole-row wash is a row treatment.
- Feed churn and `showModal()` are both reconciled in `updated()`, never `render()`: a dropped alert renders nothing and the stale id is cleared afterwards, keeping `render` side-effect free.
- A click landing on the `<dialog>` element itself is a `::backdrop` click (content sits in child elements) — that is how scrim-dismiss is detected. `Esc`, scrim and the close button all converge on the native `close` event.

## Verification

- `npm test` — 726 passed / 23 files. `npm run lint` and `npm run build` clean.
- `describe('tap_action action:details')` in `tests/card-tap-action.test.ts`: both layouts, aggregate-sensor scoping, dialog swap on re-tap, close button, native `close` (Esc/scrim), Enter/Space, no HA action fired, post-swipe click suppressed, churn auto-close — plus assertions that the pop-up contains `.alert-title` / `.alert-header-row` / `.icon-box` / `.progress-section`, the regression that would have caught the `ha-dialog` breakage.
- **jsdom trap:** it implements `<dialog>` without `showModal()` or `close()`; both are guarded with a documented degrade rather than throwing.
- Exercised live in the dev HA (section `tap_action → detail pop-up`) against a mock aggregate sensor carrying four alerts, one per severity tier.
- **Not done:** the light/dark visual pass. The `colorTheme: nws` path is the one to watch — "Small Craft Advisory" (`#D8BFD8`, contrast 1.699) trips `boost-light`, so a lost token context would regress in the **light** theme only.

## Follow-up

`tap_action` is still YAML-only in the visual editor (assumption A3 of the plan). A separate plan covers a card-owned `ha-select` control — HA's `hui-action-editor` cannot label a card-owned action value, and has no concept of "unset" as distinct from `none`, which this card needs because `hasTapAction` is presence-based.

Assisted-by: Claude:claude-opus-5
