### PR TITLE
chore(release): attach storefront figures as release assets

### DIFF
--- a/scripts/publish.sh
+++ b/scripts/publish.sh
@@ -106,3 +106,30 @@ else
     $([ "$PRERELEASE" = true ] && echo "--prerelease")
   echo "Release $TAG published"
 fi
+
+# Storefront figures, attached as release assets.
+#
+# These three are the ones consumed outside the repo: the README embeds all
+# three, and the HA Community thread embeds hero + themes. Serving them from
+# /releases/latest/download/<name> gives a permanent URL that survives a history
+# rewrite (release assets live outside git objects) and only changes when a
+# release is cut, so a bad figure can never reach either surface mid-cycle.
+#
+# release.sh has already regenerated them via `npm run screenshot:hero`.
+# Deliberately outside the guard above so re-running publish.sh refreshes the
+# assets on an existing release.
+MEDIA=(
+  img/hero-adaptive.svg
+  img/themes-adaptive.svg
+  img/surface-theming-adaptive.svg
+)
+
+for f in "${MEDIA[@]}"; do
+  if [ ! -f "$f" ]; then
+    echo "Missing $f — run 'npm run screenshot:hero', then re-run publish.sh $VERSION"
+    exit 1
+  fi
+done
+
+gh release upload "$TAG" "${MEDIA[@]}" --clobber
+echo "Storefront figures attached to $TAG"


### PR DESCRIPTION
## Summary

Attaches the three externally-consumed figures to the GitHub release as assets, giving them a permanent `/releases/latest/download/<name>` URL.

This is the enabling step for getting `img/` out of git history, and it is deliberately the *only* step taken here — it is purely additive, changes nothing about how anything is currently rendered, and unblocks the sequencing described below.

**Why release assets rather than a branch path or Pages URL:**

- They live **outside git objects**, so they survive the planned `img/` history prune — the same property that keeps HACS distribution working through a rewrite.
- They change **only when a release is cut**, not on every push, so a broken harness cannot silently replace or 404 a live figure mid-cycle.
- The **HA Community thread** is the surface that forces this. Its OP hardlinks `raw.githubusercontent.com/seevee/weather_alerts_card/main/img/{hero,themes}-adaptive.svg`. Unlike the README, a broken image there cannot be fixed by a commit — it needs a manual Discourse API edit — and it is plausibly the card's largest discovery channel.

## Changes

`scripts/publish.sh` only. One block added after release creation:

- Existence check over the three files, failing with `run 'npm run screenshot:hero', then re-run publish.sh <version>` rather than aborting partway through an upload.
- `gh release upload "$TAG" ... --clobber`, placed **outside** the `if gh release view` guard so that re-running `publish.sh` on an existing release refreshes the assets. The script is already written to be re-run safe and this preserves that.

**No CI change, no new tooling.** `release.sh` already regenerates these locally via `npm run screenshot:hero` (`build && screenshot && encode-adaptive-svgs.sh`), so this only changes how they are published. Playwright stays entirely off the shipping path, and a render failure surfaces locally before a tag is cut rather than in a workflow after it.

## What is deliberately NOT in this PR

The companion change — dropping `img/` from the `git add` in `release.sh`, which is the line that has been growing history by 1–2 MB per release — **cannot land yet**, for two independent reasons:

1. `release.sh` checks for a clean tree at L65, regenerates `img/` at L76, and absorbs the result into the release commit at L217. Remove `img/` from that `git add` and the regenerated files stay uncommitted, so the *next* release aborts on a dirty tree.
2. The README and the Discourse OP still point at `main/img/`. Until those are repointed to the release-asset URLs this PR creates, `main`'s committed figures have to stay current or both surfaces go stale.

That change belongs with the untracking step, once both storefronts have been migrated. Order: this PR → cut a stable release carrying the assets → repoint README + Discourse OP → *then* drop `git add img/` and untrack.

Note `/releases/latest/download/` resolves to the latest **non-prerelease**, so the permanent URLs do not become live until the next stable release — `v3.3.0-alpha.1` does not qualify.

## Test Plan

- [x] `bash -n scripts/publish.sh` — syntax clean
- [x] `shellcheck scripts/publish.sh` — no findings in the added block (the one SC2046 warning is pre-existing, on the `--prerelease` conditional, and left alone)
- [x] Existence guard exercised both ways in isolation: passes with the three real files present (2.2 MB total), and fails with a clear message + exit 1 when a path is missing
- [ ] `gh release upload` itself not executed — it mutates a published release, so it is untested here and will first run on the next real `publish.sh` invocation
- [x] No `src/**` changes; lint/build/test unaffected

Assisted-by: Claude:claude-opus-5
