### PR TITLE
chore(release): drop the release-asset media upload from #229

### DIFF
--- a/scripts/publish.sh
+++ b/scripts/publish.sh
@@ -106,30 +106,3 @@ else
     $([ "$PRERELEASE" = true ] && echo "--prerelease")
   echo "Release $TAG published"
 fi
-
-# Storefront figures, attached as release assets.
-#
-# These three are the ones consumed outside the repo: the README embeds all
-# three, and the HA Community thread embeds hero + themes. Serving them from
-# /releases/latest/download/<name> gives a permanent URL that survives a history
-# rewrite (release assets live outside git objects) and only changes when a
-# release is cut, so a bad figure can never reach either surface mid-cycle.
-#
-# release.sh has already regenerated them via `npm run screenshot:hero`.
-# Deliberately outside the guard above so re-running publish.sh refreshes the
-# assets on an existing release.
-MEDIA=(
-  img/hero-adaptive.svg
-  img/themes-adaptive.svg
-  img/surface-theming-adaptive.svg
-)
-
-for f in "${MEDIA[@]}"; do
-  if [ ! -f "$f" ]; then
-    echo "Missing $f — run 'npm run screenshot:hero', then re-run publish.sh $VERSION"
-    exit 1
-  fi
-done
-
-gh release upload "$TAG" "${MEDIA[@]}" --clobber
-echo "Storefront figures attached to $TAG"


### PR DESCRIPTION
## Summary

Reverts the release-asset upload added in #229. `scripts/publish.sh` is now byte-identical to its state before that PR.

**The premise was wrong.** #229 attached the three storefront SVGs to every release so the README and the HA Community thread could be repointed at permanent `/releases/latest/download/` URLs that would survive the planned `img/` history prune. Release assets cannot serve that purpose:

```
$ curl -sIL .../releases/download/v3.2.0/weather-alerts-card.js
content-disposition: attachment; filename=weather-alerts-card.js
content-type: application/octet-stream
```

An `<img>` pointing at a release asset **downloads** it rather than rendering it. Release assets are right for downloads — which is all `dist/weather-alerts-card.js` and HACS require — and unusable as an image host.

**And the migration it was enabling is no longer wanted.** #230 and #231 cut tracked media from 2951 KB to 686 KB across six files that change a few times a year. The storefront can simply stay on `raw.githubusercontent.com`, which deletes the Phase 2b repoint from the docs plan entirely — along with the risk it carried of breaking the forum thread, whose OP can only be fixed by a manual API edit.

That left the upload attaching ~499 KB to every release for no consumer, plus a step that can fail *after* `gh release create` has already published.

## Changes

- `scripts/publish.sh`: removes the `MEDIA` array, the existence guard and the `gh release upload` call.

## Verification

- [x] `git diff 082f2fd -- scripts/publish.sh` is empty — an exact revert to the pre-#229 file, not an approximation
- [x] `bash -n` clean; `shellcheck` reports only the pre-existing SC2046 on the `--prerelease` conditional
- [x] **No cleanup needed on GitHub.** The newest release (`v3.3.0-alpha.1`, 2026-07-20) predates #229's merge (2026-08-03), so the upload never ran and no published release carries these assets

Assisted-by: Claude:claude-opus-5
