### PR TITLE
docs(site): add a VitePress documentation site on GitHub Pages

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -1,0 +1,54 @@
+name: Docs
+
+on:
+  push:
+    branches: [main]
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  pages: write
+  id-token: write
+
+# One deploy at a time; let an in-flight run finish rather than cancelling it.
+concurrency:
+  group: pages
+  cancel-in-progress: false
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+      - uses: actions/setup-node@v6
+        with:
+          node-version: 20
+          cache: 'npm'
+      - run: npm ci
+
+      # The figures are rendered from the real card in headless Chromium, so the
+      # docs build needs a browser. Scoped to this workflow — build.yml and
+      # release.yml stay Playwright-free.
+      - run: npx playwright install --with-deps chromium
+
+      # Builds dist/, renders every figure, and stages them in docs/public/img/.
+      # DOCS_MOTION is deliberately unset: the motion capture is still being
+      # tuned, and it would add an ffmpeg/ffprobe dependency to this runner.
+      - run: npm run docs:media
+
+      - run: npm run docs:build
+
+      - uses: actions/configure-pages@v5
+      - uses: actions/upload-pages-artifact@v3
+        with:
+          path: docs/.vitepress/dist
+
+  deploy:
+    needs: build
+    runs-on: ubuntu-latest
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+    steps:
+      - id: deployment
+        uses: actions/deploy-pages@v4

--- a/.gitignore
+++ b/.gitignore
@@ -23,6 +23,13 @@ img/*
 !img/surface-theming-adaptive.svg
 !img/surface-theming-light.webp
 
+# Docs site build output. Docs figures are regenerated from the harnesses on
+# every Pages build (scripts/build-docs-media.sh), so docs/public/img/ is a
+# build artifact too — the only committed figures are the six above.
+docs/.vitepress/dist/
+docs/.vitepress/cache/
+docs/public/img/
+
 # Dependencies
 node_modules/
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -139,6 +139,62 @@ The card needs the `sensor.nws_alerts_alerts` entity which comes from the [NWS A
 
    **Important**: zone codes must be comma-delimited with **no spaces** (e.g. `COC059,COZ039,COZ239`). Adding spaces after commas (e.g. `COC059, COZ039`) causes the integration to silently return no alerts. Find your zone codes at https://alerts.weather.gov/.
 
+## Documentation Site
+
+A [VitePress](https://vitepress.dev) site under `docs/`, deployed to GitHub Pages at
+`https://seevee.github.io/weather_alerts_card/`.
+
+```bash
+npm run docs:media    # regenerate figures → docs/public/img/ (scripts/build-docs-media.sh)
+npm run docs:dev      # dev server with hot reload
+npm run docs:build    # production build → docs/.vitepress/dist/
+npm run docs:preview  # serve the production build
+```
+
+| File | Purpose |
+|------|---------|
+| `docs/.vitepress/config.mts` | Site config. **Must be `.mts`** — this package is CJS (no `"type": "module"`), so a `.ts` config is loaded as CommonJS and fails on VitePress's ESM-only export, same reason `rollup.config.mjs` is `.mjs`. |
+| `docs/*.md`, `docs/recipes/*.md` | Content: overview, getting-started, configuration, theming, providers, two recipe pages, development. |
+| `scripts/build-docs-media.sh` | Builds `dist/`, runs `screenshot.js` + `encode-adaptive-svgs.sh`, copies `img/` output into `docs/public/img/`. |
+| `.github/workflows/docs.yml` | Pages build + deploy on push to `main` and `workflow_dispatch`. Installs Playwright Chromium; `build.yml`/`release.yml` stay Playwright-free. |
+
+Conventions that are load-bearing:
+
+- **`base` is `/weather_alerts_card/`.** Project Pages serve under the repo name; a wrong
+  base 404s every asset. In Markdown, reference figures as `/img/<name>` — VitePress
+  prepends the base itself, so writing the base explicitly doubles it.
+- **Docs figures are not committed.** They are regenerated on every Pages build, and
+  `docs/public/img/` plus `docs/.vitepress/{dist,cache}/` are gitignored. The only
+  tracked figures are the six the README embeds.
+- **`docs:media` must run before `docs:build`** on a fresh clone — VitePress hard-fails on
+  an unresolvable image rather than warning.
+- **`docs:media` dirties the six tracked figures.** Scene content is deterministic (frozen
+  clock, fixed fixtures) but encoded bytes are not portable across Chromium/ImageMagick
+  versions. `git restore img/` after a local run; refreshing the storefront is a
+  release-time job. Harmless in CI, which commits nothing.
+- **The motion capture is gated behind `DOCS_MOTION=1`,** off by default — still being
+  tuned, and it needs both `ffmpeg` and `ffprobe` (`capture-tap-action.js` probes only for
+  `ffmpeg`, so a runner with one and not the other throws rather than degrading).
+- **VitePress is pinned to 1.x.** 2.0 requires Node 22+ and all three workflows run Node
+  20; the migration is mostly that Node bump.
+
+Three surfaces consume these figures, which is why the pipeline looks the way it does:
+
+1. **README** (the HACS storefront) — `hacs.json` sets `render_readme: true` and HACS
+   validation requires the README to contain images, so it must stay self-sufficient. The
+   docs site duplicates its content deliberately; do not thin the README to remove the
+   duplication.
+2. **The HA Community thread** — renders only Markdown `![alt|WxH](url)`. No `<picture>`,
+   no `prefers-color-scheme`, no HTML.
+3. **The docs site.**
+
+Because of (2), the **adaptive SVGs must not be "optimized" into `<picture>` elements** —
+a single self-adapting URL is the only way to get a theme-aware figure onto the forum.
+And never link a reader *directly* at one: `raw.githubusercontent.com` serves SVG under
+`default-src 'none'`, which blocks `img-src`, and these SVGs are nothing but two base64
+`<image>` elements, so a direct link renders blank. Display the SVG, link to the light
+WebP.
+
 ## Agent Rules
 
 These rules apply to all autonomous agent skills (`/explore`, `/plan`, `/implement`, `/fix`, `/review`).

--- a/README.md
+++ b/README.md
@@ -4,6 +4,15 @@ A custom Home Assistant Lovelace card for displaying weather alerts with severit
 
 [![Weather Alerts Card](https://raw.githubusercontent.com/seevee/weather_alerts_card/main/img/hero-adaptive.svg)](https://raw.githubusercontent.com/seevee/weather_alerts_card/main/img/hero-light.webp)
 
+## Documentation
+
+📖 **[Full documentation →](https://seevee.github.io/weather_alerts_card/)** — getting
+started, the complete configuration reference, theming, per-provider notes, and pop-up
+recipes.
+
+This README covers everything you need to install and configure the card. The docs site
+is the same material with more room to breathe, plus per-provider setup detail.
+
 ## Features
 
 - **Multi-provider** — NWS (US), BoM (Australia), MeteoAlarm (Europe), DWD (Germany), MeteoSwiss (Switzerland), ECCC (Canada), NSW RFS (Australian bushfire), PirateWeather, and CAP Alerts (multi-region) with auto-detection

--- a/docs/.vitepress/config.mts
+++ b/docs/.vitepress/config.mts
@@ -1,0 +1,69 @@
+import { defineConfig } from 'vitepress';
+
+// Pinned to VitePress 1.x deliberately: 2.0 requires Node 22+, and CI runs
+// Node 20 across build.yml, release.yml and docs.yml. Revisit after that bump.
+export default defineConfig({
+  title: 'Weather Alerts Card',
+  description:
+    'A custom Home Assistant Lovelace card for weather alerts — multi-provider, severity-aware, with progress bars and expandable details.',
+
+  // Project Pages serve under the repository name. Without this every asset
+  // and internal link 404s on the deployed site.
+  base: '/weather_alerts_card/',
+
+  lastUpdated: true,
+  cleanUrls: false,
+
+  head: [
+    ['meta', { name: 'theme-color', content: '#03a9f4' }],
+  ],
+
+  themeConfig: {
+    nav: [
+      { text: 'Getting Started', link: '/getting-started' },
+      { text: 'Configuration', link: '/configuration' },
+      { text: 'Providers', link: '/providers' },
+      { text: 'Recipes', link: '/recipes/detail-popup' },
+    ],
+
+    sidebar: [
+      {
+        text: 'Guide',
+        items: [
+          { text: 'Overview', link: '/' },
+          { text: 'Getting Started', link: '/getting-started' },
+          { text: 'Configuration', link: '/configuration' },
+          { text: 'Theming', link: '/theming' },
+          { text: 'Providers', link: '/providers' },
+        ],
+      },
+      {
+        text: 'Recipes',
+        items: [
+          { text: 'Per-alert detail pop-up', link: '/recipes/detail-popup' },
+          { text: 'Bubble Card pop-up', link: '/recipes/bubble-card-popup' },
+        ],
+      },
+      {
+        text: 'Contributing',
+        items: [{ text: 'Development', link: '/development' }],
+      },
+    ],
+
+    socialLinks: [
+      { icon: 'github', link: 'https://github.com/seevee/weather_alerts_card' },
+    ],
+
+    search: { provider: 'local' },
+
+    editLink: {
+      pattern: 'https://github.com/seevee/weather_alerts_card/edit/main/docs/:path',
+      text: 'Edit this page on GitHub',
+    },
+
+    footer: {
+      message: 'Released under the MIT License.',
+      copyright: 'Not affiliated with, or endorsed by, any weather agency.',
+    },
+  },
+});

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -1,0 +1,336 @@
+# Configuration
+
+Every option below is also available in the visual editor — no YAML editing is
+required. This page is the reference for what each one does.
+
+::: tip Surfaces are themed, not configured
+Backgrounds, borders, corners, shadows and translucency are **not** card options.
+They are CSS custom properties. See [Theming](./theming).
+:::
+
+## Sources
+
+Where the card gets its alerts. At least one of `entity`, `device` or `sources` is
+required; they can be combined freely.
+
+| Option | Default | Description |
+|--------|---------|-------------|
+| `entity` | *(required, unless `device` or `sources` is set)* | Alert sensor entity |
+| `entities` | — | Additional alert entities to merge (e.g. DWD current + advance) |
+| `device` | — | HA `device_id` — auto-discovers all per-alert sensors under that device, and re-discovers as alerts come and go. Currently only the CAP Alerts integration uses this shape |
+| `sources` | — | Feed `source` attribute values to auto-collect, e.g. `['nsw_rural_fire_service_feed']` |
+| `provider` | auto-detect | `'nws'`, `'bom'`, `'meteoalarm'`, `'dwd'`, `'meteoswiss'`, `'eccc'`, `'nsw_rfs'`, `'pirateweather'`, `'cap'` |
+
+### Collecting a whole feed with `sources`
+
+Some integrations create **one entity per incident** rather than one aggregate sensor,
+and that set churns constantly as incidents start and clear. `sources` harvests every
+entity whose `source` attribute matches, re-scanning on each render — so there are no
+volatile entity ids to hand-list:
+
+```yaml
+type: custom:weather-alerts-card
+sources:
+  - nsw_rural_fire_service_feed
+```
+
+`sources` is independent of `provider`: each collected entity still auto-detects its
+own adapter. In the visual editor this is the **Auto-collect from installed feeds**
+checkbox, which appears only when a matching integration is installed.
+
+## Filtering and sorting
+
+| Option | Default | Description |
+|--------|---------|-------------|
+| `zones` | — | Restrict to specific zone codes, matched against each alert's zone list |
+| `sortOrder` | `'default'` | `'default'`, `'onset'`, `'severity'` |
+| `minSeverity` | `'all'` | `'all'`, `'minor'`, `'moderate'`, `'severe'`, `'extreme'` |
+| `eventCodes` | — | Event codes to include, e.g. `['SVR', 'TOR']` (NWS) or `['31', '95']` (DWD) |
+| `excludeEventCodes` | — | Event codes to exclude, e.g. `['SCY']` (NWS) or `['22']` (DWD) |
+| `hideExpired` | `true` | Hide expired alerts (set `false` to show them dimmed) |
+| `hideNoAlerts` | `false` | Hide the "No active alerts" banner when there are no alerts |
+| `deduplicate` | `true` | Collapse matching alerts across zones and providers |
+| `deduplicateHeadlines` | `true` | Suppress headlines that merely repeat the event name |
+
+::: warning `zones` hides everything on providers that carry no zone codes
+Zone lists are populated by CAP Alerts (UGC, SAME, EMMA_ID, NUTS and any other geocode
+scheme) and BoM (`area_id`, e.g. `NSW_FL049` — fork-dependent; the `safepay/ha_bom_australia`
+fork emits it). **Alerts with no matching zone are hidden**, so setting `zones` on a
+provider that carries none hides every alert. The recommended NWS integration does not
+emit zone codes.
+:::
+
+`minSeverity` never hides an alert whose severity is unknown or unclassified — those are
+always shown, on the principle that an unrankable alert must not be silently dropped.
+
+## Presentation
+
+| Option | Default | Description |
+|--------|---------|-------------|
+| `title` | — | Card header title |
+| `layout` | `'default'` | `'default'` or `'compact'` |
+| `fontSize` | `'default'` | `'small'`, `'default'`, `'large'`, `'x-large'` — scales text and icons |
+| `colorTheme` | `'severity'` | `'severity'`, `'nws'`, `'meteoalarm'`, `'eccc'` |
+| `enhanceContrast` | `'subtle'` | `'off'`, `'subtle'`, `'strict'` — see below |
+| `progressFill` | `'track'` | `'track'` (thin bar) or `'background'` (whole-row wash) |
+| `progressStyle` | see below | Per-phase progress-bar decoration |
+| `iconBorderStyle` | see below | Per-phase icon-ring border style |
+| `animations` | system | `true`, `false`, or respect `prefers-reduced-motion`. Gates *motion* only |
+| `showProvider` | `false` | Show a provider label (e.g. NWS) above the event title |
+| `timezone` | `'server'` | `'server'` or `'browser'` (the client's local time) |
+
+`colorTheme: 'eccc'` uses ECCC's published red/orange/yellow/grey palette (matching
+weather.gc.ca) and falls back to the canonical severity tier for non-ECCC alerts shown
+under it. See [Theming](./theming) for what each palette looks like.
+
+### `enhanceContrast`
+
+Official agency palettes were designed for print and for maps, not for a dark-mode
+dashboard card. Some event colors — yellow Tornado Watch is the classic — are nearly
+invisible against one theme's background while reading fine against the other.
+
+`enhanceContrast` boosts foreground colors **per event, per theme mode, and only in the
+direction where they fail**. Events that already read cleanly (e.g. Tornado Warning)
+render unchanged in every mode.
+
+- `'subtle'` *(default)* — a text tier (~2:1 for icon and label) plus a stricter
+  progress tier (~1.3:1 for the progress-bar fill, which is what catches near-invisible
+  tints).
+- `'strict'` — tightens both tiers (text ~3:1, progress ~2:1) toward WCAG AA-ish
+  guarantees.
+- `'off'` — always render the raw theme hex values.
+
+Applies to the `nws` and `meteoalarm` themes.
+
+### `progressStyle` and `iconBorderStyle`
+
+Both take an object with optional `preparation` / `active` / `ongoing` keys, matching an
+alert's three live phases. The `expired` phase is a fixed dimmed style and is not
+configurable.
+
+- `progressStyle` values: `'solid'`, `'striped'`, `'shimmer'`, `'pulse'`.
+  Defaults: `preparation: striped`, `active: shimmer`, `ongoing: pulse`.
+- `iconBorderStyle` values: `'dashed'`, `'solid'`.
+  Defaults: `preparation: dashed`, `active: solid`, `ongoing: solid`.
+
+```yaml
+type: custom:weather-alerts-card
+entity: sensor.nws_alerts_alerts
+progressStyle:
+  preparation: solid      # a straight pre-onset bar instead of diagonal dashes
+  active: striped         # stripes that march with the bar
+iconBorderStyle:
+  preparation: solid      # solid pre-onset ring instead of the default dashed
+```
+
+Flow direction is intrinsic to each phase: a texture keeps its phase's direction
+wherever you place it, so `active: striped` still marches with the bar.
+
+::: warning Two caveats
+**`ongoing: solid`** — a static full-width ongoing bar no longer signals "indeterminate,
+no known end", and can read like a nearly-expired alert. The default stays `pulse` for
+that reason.
+
+**`progressStyle` has no effect under `progressFill: background`** — that mode hides the
+thin track the texture decorates, and a texture is imperceptible at the wash's
+legibility-safe opacity. The wash is always solid.
+:::
+
+## The detail panel
+
+| Option | Default | Description |
+|--------|---------|-------------|
+| `showDetails` | `true` | Show the expandable detail panel (hides the entire "Read Details" section when `false`) |
+| `expandDetails` | `false` | Always show details inline without a toggle — ideal for wall-mounted displays |
+| `showMetadata` | `true` | Show the issued/onset/expires/area grid |
+| `showDescription` | `true` | Show description text |
+| `showInstructions` | `true` | Show instructions text |
+| `showSourceLink` | `true` | Show the "Open Source" link (`false` for kiosk mode) |
+| `reformatText` | `true` | Strip hard line wraps from alert text (NWS 69-char teletype breaks) while preserving paragraph breaks |
+| `showGeometry` | `false` | Show an inline mini-map of the affected-area outline |
+| `geometryStyle` | `'shape'` | `'shape'` (bare outline) or `'map'` (raster-tile basemap) |
+| `geometryTileUrl` | CARTO | Slippy-map tile template (`{z}/{x}/{y}`, optional `{s}`) used when `geometryStyle: 'map'` |
+| `geometryTileAttribution` | `© OpenStreetMap, CARTO` | Attribution label shown over the map |
+
+### Affected-area mini-map
+
+![The affected-area mini-map, as a bare outline and over a raster basemap](/img/geometry-adaptive.svg)
+
+`showGeometry` is **CAP Alerts (`cap_alerts`) only** — no other provider carries
+geometry. The card draws the bounding-box frame immediately and overlays the polygon
+once it has been fetched out of band, falling back to the frame alone on a cache miss.
+
+::: warning `geometryStyle: 'map'` goes online
+The default `'shape'` is fully offline. `'map'` fetches map tiles, which **reveals the
+alert's bounding box to the tile host**. It is opt-in for that reason, and falls back to
+the plain outline if tiles fail. The default tile source is the theme-aware CARTO
+basemap Home Assistant's own map uses (`light_all` / `dark_all`, CORS-enabled); override
+`geometryTileUrl` to point at a self-hosted or proxied source, and set
+`geometryTileAttribution` to credit it.
+:::
+
+## Broken sources
+
+![The degraded badge naming a broken source](/img/unavailable-adaptive.svg)
+
+| Option | Default | Description |
+|--------|---------|-------------|
+| `unavailableBehavior` | `'message'` | `'message'`, `'compact'`, `'hide'` |
+
+When *some or all* configured sources are broken — unavailable or unknown, with no
+parseable alert — the card shows a degraded badge above its content rather than
+rendering an empty, reassuring card. **A dead feed is not proof of safety.**
+
+- `'message'` — the badge names the broken source (and counts them when there is more
+  than one).
+- `'compact'` — an icon-only badge.
+- `'hide'` — no badge. **Not recommended.**
+
+A visible badge keeps the card on screen even under `hideNoAlerts`. The card hides
+completely only when there are no alerts **and** `hideNoAlerts` is set **and** either
+`unavailableBehavior: 'hide'` or nothing is actually broken.
+
+## Dismissal
+
+| Option | Default | Description |
+|--------|---------|-------------|
+| `allowDismiss` | `false` | Let users dismiss individual alerts (browser-local) |
+| `dismissTrigger` | `'button'` | `'button'`, `'swipe'`, or `'both'` — swipe covers touch and mouse drag |
+| `dismissButtonStyle` | `'icon'` | `'icon'` or `'labeled'` (icon + "Dismiss" text) |
+| `showDismissUndo` | `true` | Show an Undo toast when an alert is dismissed |
+
+Dismissal is **browser-local** — it is a way to clear something you have already read
+off your own screen, not a shared acknowledgement. A restore-all control brings
+dismissed alerts back, and an alert re-surfaces on its own if its severity, issue time,
+expiry, or phase changes.
+
+`dismissButtonStyle` has no effect when `dismissTrigger: 'swipe'` (no button is
+rendered), and the compact layout is always icon-only.
+
+## Tap actions
+
+| Option | Default | Description |
+|--------|---------|-------------|
+| `tap_action` | — | Standard Home Assistant action fired when an alert row is tapped |
+
+**Setting `tap_action` replaces the inline expand affordance.** The whole row becomes the
+tap target, and the compact chevron / "Read Details" toggle is removed. In
+`layout: default`, `expandDetails: true` still renders the always-on detail panel below
+the row.
+
+Supported actions: `details`, `more-info`, `navigate`, `url`, `toggle`, `call-service`
+(alias `perform-action`), `fire-dom-event`, `none`.
+
+- **`details`** is card-owned rather than a standard HA action: it opens the tapped
+  alert in a modal showing the whole alert body, per-alert for every provider and with
+  no add-ons. See [Per-alert detail pop-up](./recipes/detail-popup).
+- **`more-info` / `toggle`** resolve their entity **per tapped alert** —
+  `tap_action.entity` (explicit) → the alert's own source sensor → `entity`. So
+  per-alert providers (CAP Alerts, NSW RFS) open *that* alert's sensor, while aggregate
+  providers (NWS, DWD, …) fall back to the aggregate sensor. `toggle` uses the generic
+  `homeassistant.toggle` service.
+- **`none`** is an inert chip: the toggle is removed but tapping does nothing.
+- **`assist`** is intentionally unsupported — it has no meaning on an alert row.
+
+Omitting `tap_action` entirely leaves today's inline expand/toggle behaviour unchanged.
+
+## Examples
+
+**Basic**
+
+```yaml
+type: custom:weather-alerts-card
+entity: sensor.nws_alerts_alerts
+```
+
+**BoM with a title and zone filtering**
+
+```yaml
+type: custom:weather-alerts-card
+entity: sensor.sydney_warnings
+provider: bom
+title: Weather Alerts
+zones:
+  - NSW_FL049
+```
+
+**NWS official colors, compact, sorted by severity**
+
+```yaml
+type: custom:weather-alerts-card
+entity: sensor.nws_alerts_alerts
+colorTheme: nws
+layout: compact
+sortOrder: severity
+```
+
+**NWS filtered to specific event types, in browser time**
+
+```yaml
+type: custom:weather-alerts-card
+entity: sensor.nws_alerts_alerts
+eventCodes:
+  - TOR
+  - SVR
+timezone: browser
+```
+
+**DWD current + advance warnings merged**
+
+```yaml
+type: custom:weather-alerts-card
+entity: sensor.dwd_weather_warnings_current
+entities:
+  - sensor.dwd_weather_warnings_advance
+```
+
+**CAP Alerts — auto-discover every alert sensor under a device**
+
+```yaml
+type: custom:weather-alerts-card
+device: 1a2b3c4d5e6f7a8b9c0d1e2f3a4b5c6d
+```
+
+Per-provider examples live on the [Providers](./providers) page.
+
+## Config schema
+
+For reference, the full TypeScript shape the card accepts:
+
+```typescript
+interface WeatherAlertsCardConfig {
+  entity: string;              // required — e.g. "sensor.nws_alerts_alerts"
+  entities?: string[];         // additional entities to merge alerts from
+  device?: string;             // HA device_id — auto-discovers per-alert sensors under it
+  sources?: string[];          // feed `source` values to auto-collect, re-scanned each render
+  title?: string;              // optional card header
+  zones?: string[];            // zone filter — e.g. ["COC059", "COZ039"]
+  eventCodes?: string[];       // event codes to include — empty/omitted = all
+  excludeEventCodes?: string[]; // event codes to exclude — empty/omitted = none
+  minSeverity?: AlertSeverity; // 'all' | 'minor' | 'moderate' | 'severe' | 'extreme'
+  sortOrder?: 'default' | 'onset' | 'severity';
+  animations?: boolean;        // undefined: respect prefers-reduced-motion; true/false: force
+  layout?: 'default' | 'compact';
+  fontSize?: 'small' | 'default' | 'large' | 'x-large';
+  colorTheme?: 'severity' | 'nws' | 'meteoalarm' | 'eccc';
+  enhanceContrast?: 'off' | 'subtle' | 'strict';
+  provider?: AlertProvider;    // undefined: auto-detect
+  deduplicate?: boolean;
+  deduplicateHeadlines?: boolean;
+  reformatText?: boolean;      // strip hard line wraps from alert text
+  hideExpired?: boolean;
+  hideNoAlerts?: boolean;
+  showDetails?: boolean;
+  expandDetails?: boolean;     // details always visible, toggle removed
+  showProvider?: boolean;
+  showMetadata?: boolean;
+  showDescription?: boolean;
+  showInstructions?: boolean;
+  showSourceLink?: boolean;    // false for kiosk mode
+  timezone?: 'server' | 'browser';
+  allowDismiss?: boolean;      // browser-local, keyed on entity-set hash
+  showDismissUndo?: boolean;
+  dismissTrigger?: 'button' | 'swipe' | 'both';
+  dismissButtonStyle?: 'icon' | 'labeled';
+}
+```

--- a/docs/development.md
+++ b/docs/development.md
@@ -1,0 +1,109 @@
+# Development
+
+The card is a single LitElement bundled with Rollup and distributed through HACS. No
+framework, no build server — clone, `npm install`, and build.
+
+## Build commands
+
+```bash
+npm install
+npm run build      # Rollup bundle → dist/weather-alerts-card.js
+npm run watch      # Rollup in watch mode
+npm run lint       # TypeScript type-check (tsc --noEmit)
+npm run test       # Vitest unit tests (jsdom)
+npm run test:watch # Vitest in watch mode
+```
+
+Run `npm run lint` and `npm run test` before committing — both are required status
+checks on every PR.
+
+The bundle is a single ES module, minified and downleveled to ES2019 so it keeps working
+in the old Android WebViews some wall panels still ship
+([#194](https://github.com/seevee/weather_alerts_card/issues/194)).
+
+## Source layout
+
+| File | Purpose |
+|------|---------|
+| `src/weather-alerts-card.ts` | The main card class. Implements the HA card contract (`setConfig()`, `hass`, `getCardSize()`, `getStubConfig()`, `window.customCards`) and wraps output in `<ha-card>` |
+| `src/weather-alerts-card-editor.ts` | The visual configuration editor |
+| `src/types.ts` | `WeatherAlert` (normalized), `WeatherAlertsCardConfig`, `AlertAdapter`, raw provider shapes |
+| `src/adapters/index.ts` | Adapter registry and auto-detection — exports `getAdapter(provider, attributes)` |
+| `src/adapters/*.ts` | One adapter per provider |
+| `src/localize.ts` | i18n lookup — `t(key, lang, params?)`, strips the region subtag, falls back to English per key |
+| `src/translations/` | One file per locale (`en`, `fr`, `es`, `it`, `de`, `zh-Hans`) |
+| `src/utils.ts` | Pure functions: icon mapping, timestamp parsing, `computeAlertProgress()`, severity normalization, zone filtering, sorting, `reflowAlertText()` |
+| `src/styles.ts` | All CSS, as a Lit `css` tagged template |
+
+## The adapter pattern
+
+Every provider is an **adapter** that converts raw entity attributes into a normalized
+`WeatherAlert[]`. The card UI only ever consumes `WeatherAlert` — never raw provider
+data. That is what keeps every feature working identically across nine feeds, and it is
+the constraint to respect when adding a tenth.
+
+An adapter declares how to detect itself from an attribute signature, and
+`getAdapter()` resolves either an explicit `config.provider` or the first adapter that
+claims the attributes. Adapters that collect per-incident entities also declare
+`feedSources`, which drives the editor's live-detected feed picker via
+`knownFeedSources()`.
+
+Two conventions worth knowing:
+
+- **Never invent data.** If a feed has no expiry, the alert gets `endsTs: 0` and the card
+  shows an honest "ongoing" state rather than a fabricated countdown. If severity had to
+  be guessed, it is flagged as inferred so the UI can mark it with a tilde.
+- **Normalize in the adapter, not the UI.** Provider quirks stop at the adapter boundary.
+
+## Adding a provider
+
+1. Add `src/adapters/<name>.ts` exporting an `AlertAdapter` — a detector plus a parser
+   producing `WeatherAlert[]`.
+2. Register it in `src/adapters/index.ts`.
+3. Add the provider to the `AlertProvider` union in `src/types.ts`.
+4. Add unit tests under `tests/` covering a real captured payload.
+5. Document it in [Providers](./providers), including its severity/certainty fidelity.
+
+## Documentation site
+
+This site is [VitePress](https://vitepress.dev), living under `docs/`.
+
+```bash
+npm run docs:media    # regenerate the figures into docs/public/img/
+npm run docs:dev      # local dev server with hot reload
+npm run docs:build    # production build → docs/.vitepress/dist/
+npm run docs:preview  # serve the production build
+```
+
+Run `docs:media` **before** `docs:build` on a fresh clone: the figures are not committed,
+and VitePress fails the build on an image it cannot resolve rather than warning.
+
+Docs figures are generated deterministically from the screenshot harnesses in `scripts/`
+and published straight into the Pages artifact, so `docs/public/img/` is gitignored. The
+only committed figures are the six the README embeds.
+
+::: warning `docs:media` leaves the tracked figures dirty
+The scene content is deterministic, but the encoded bytes are not portable across
+Chromium and ImageMagick versions — so the run rewrites the six storefront figures in
+place. Run `git restore img/` afterwards unless you actually mean to refresh them, which
+is a release-time job.
+:::
+
+The motion capture (`scripts/capture-tap-action.js`) is gated behind `DOCS_MOTION=1` and
+off by default. It needs both `ffmpeg` and `ffprobe`.
+
+Deployment is `.github/workflows/docs.yml`, which builds and publishes to GitHub Pages on
+every push to `main`.
+
+## Contributing
+
+- Branches: `feat/<name>`, `fix/<name>`, `chore/<name>`.
+- Commits: `type(scope): description` — `feat`, `fix`, `docs`, `refactor`, `test`,
+  `chore`.
+- `main` is protected. Everything goes through a PR with passing build, lint, test and
+  HACS validation checks, and only squash merges are allowed.
+
+See [CONTRIBUTING.md](https://github.com/seevee/weather_alerts_card/blob/main/CONTRIBUTING.md)
+for the full guidelines, and
+[AGENTS.md](https://github.com/seevee/weather_alerts_card/blob/main/AGENTS.md) for
+repository conventions in the depth an automated contributor needs.

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -1,0 +1,108 @@
+# Getting Started
+
+## Quick start
+
+1. Install a weather alerts integration for your region — see [Providers](./providers).
+2. Install this card via HACS: search **Weather Alerts Card**.
+3. Add it to your dashboard and select your alert entity.
+
+That is usually the whole job. The card auto-detects which provider an entity belongs
+to from its attributes, so a minimal config is just an entity:
+
+```yaml
+type: custom:weather-alerts-card
+entity: sensor.nws_alerts_alerts
+```
+
+::: tip Order matters
+Install the integration **first**. Without an alert entity to point at, the card has
+nothing to render and the entity picker will look empty.
+:::
+
+## Installation
+
+### HACS (recommended)
+
+[![Open your Home Assistant instance and open a repository inside the Home Assistant Community Store.](https://my.home-assistant.io/badges/hacs_repository.svg)](https://my.home-assistant.io/redirect/hacs_repository/?owner=seevee&repository=weather_alerts_card)
+
+Click **Download**, then **Reload** when prompted. HACS manages the dashboard resource
+for you — there is nothing further to register.
+
+### Manual
+
+1. Download `weather-alerts-card.js` from the [latest release](https://github.com/seevee/weather_alerts_card/releases/latest).
+2. Copy it to `config/www/weather-alerts-card.js`.
+3. Add it as a resource: **Settings → Dashboards → Resources** →
+   URL `/local/weather-alerts-card.js`, Type **JavaScript Module**.
+
+## Adding the card
+
+Use the visual editor — every option is exposed there, and the entity picker only
+offers entities the card can actually read. **Add Card → search "Weather Alerts
+Card"**.
+
+To hand-write it instead, add a **Manual** card with the YAML above. From there, see
+the [configuration reference](./configuration) for the full option list.
+
+## A more complete example
+
+A typical setup filters to the alerts you care about and sorts the worst to the top:
+
+```yaml
+type: custom:weather-alerts-card
+entity: sensor.nws_alerts_alerts
+title: Weather Alerts
+layout: compact
+sortOrder: severity
+minSeverity: moderate
+colorTheme: nws
+```
+
+## Verifying it works
+
+Severe weather is, happily, rare — so an empty card is the normal state and tells you
+little. Two things to check:
+
+- The card renders a **"No active alerts"** banner rather than an error. That means the
+  entity was found and parsed.
+- Turn on `hideExpired: false` temporarily. Recently expired alerts render dimmed, which
+  is usually enough to confirm the pipeline end to end without waiting for a storm.
+
+If a source breaks, the card does **not** quietly fall back to "no alerts" — it shows a
+degraded badge naming the broken sensor. See `unavailableBehavior` in the
+[configuration reference](./configuration).
+
+## Migrating to v3
+
+v3.0.0 removed backwards-compatibility shims that were deprecated in v2. Upgrading from
+v1.x or v2.x needs these changes.
+
+**1. Card type rename** (v1.x only)
+
+```yaml
+# Before
+type: custom:nws-alerts-card
+
+# After
+type: custom:weather-alerts-card
+```
+
+**2. `headline` key removed** (v1.x only)
+
+`headline` was replaced by `deduplicateHeadlines` in v2:
+
+```yaml
+# Before
+headline: true
+
+# After
+deduplicateHeadlines: true
+```
+
+**3. Manual installs: resource filename changed**
+
+| Before | After |
+|--------|-------|
+| `/local/nws-alerts-card.js` | `/local/weather-alerts-card.js` |
+
+HACS users need do nothing — HACS manages the resource path.

--- a/docs/index.md
+++ b/docs/index.md
@@ -1,0 +1,82 @@
+---
+layout: home
+
+hero:
+  name: Weather Alerts Card
+  text: Weather alerts, done properly
+  tagline: A custom Home Assistant Lovelace card for severe-weather alerts — nine providers, severity-aware colors, time progress bars and expandable details.
+  image:
+    src: /img/hero-adaptive.svg
+    alt: The Weather Alerts Card showing several active alerts
+  actions:
+    - theme: brand
+      text: Get started
+      link: /getting-started
+    - theme: alt
+      text: Configuration reference
+      link: /configuration
+    - theme: alt
+      text: View on GitHub
+      link: https://github.com/seevee/weather_alerts_card
+
+features:
+  - title: Multi-provider
+    details: NWS (US), BoM (Australia), MeteoAlarm (Europe), DWD (Germany), MeteoSwiss, ECCC (Canada), NSW RFS, PirateWeather and CAP Alerts — with auto-detection from entity attributes.
+  - title: Color themes
+    details: Severity-based by default, or the official NWS event, MeteoAlarm awareness-level, or ECCC public-alert palettes — with per-event contrast correction.
+  - title: Time progress bars
+    details: Elapsed and remaining time with relative and absolute timestamps, and honest "ongoing" handling for feeds that carry no expiry.
+  - title: Expandable details
+    details: Sanitized description, instructions and a source link — inline, or in a per-alert modal via tap_action.
+  - title: Affected-area mini-map
+    details: An optional inline outline of a CAP alert's polygon, with an opt-in raster-tile basemap for geographic context.
+  - title: Broken-source safety badge
+    details: When a configured sensor goes unavailable, a degraded indicator names the broken source. A dead feed is never treated as proof of safety.
+  - title: Themeable surfaces
+    details: A small, stable set of --wac-* CSS custom properties for backgrounds, borders, corners and shadows. No card config needed.
+  - title: Localized UI
+    details: English, French, Spanish, Italian, German and Simplified Chinese, auto-detected from your Home Assistant locale.
+  - title: Visual config
+    details: Every option is available in the visual editor. No YAML editing required.
+---
+
+## What it does
+
+The card reads an alert sensor from a weather integration and renders each active
+alert with a severity color, an icon, a headline, and a progress bar showing how
+much of the alert's window has elapsed. Tapping an alert expands the full
+description and instructions.
+
+Nine providers are supported through an **adapter** layer: whatever integration you
+run, the card normalizes its output into one internal alert shape, so every feature
+below behaves the same regardless of where the data came from. In most cases you
+only have to point the card at an entity — the provider is auto-detected.
+
+## Where to go next
+
+| If you want to… | Read |
+|---|---|
+| Install the card and get a first alert on screen | [Getting Started](./getting-started) |
+| Look up a config option | [Configuration](./configuration) |
+| Change colors, surfaces, or translucency | [Theming](./theming) |
+| Find the right integration for your region | [Providers](./providers) |
+| Open alerts in a pop-up instead of expanding inline | [Recipes](./recipes/detail-popup) |
+| Build the card from source | [Development](./development) |
+
+## Beyond the basics
+
+- **Filtering** — restrict by zone code, event code, or a minimum severity threshold.
+- **Layouts** — a full card, or a `compact` one-row-per-alert list that expands on tap.
+- **Dismissal** — optional per-alert dismiss by button or swipe, with undo and a
+  restore-all control, stored browser-locally.
+- **Deduplication** — collapse the same alert repeated across zones and providers.
+
+## Support
+
+If you find this card useful, tip the author at [Ko-fi](https://ko-fi.com/seeveezee),
+or donate to [The Y'all Squad](https://www.theyallsquad.org/donate) — a rapid-response
+program providing direct aid, chainsaws, and supplies to families affected by severe
+weather events.
+
+Questions and screenshots are welcome on the
+[Home Assistant Community thread](https://community.home-assistant.io/t/weather-alerts-card).

--- a/docs/providers.md
+++ b/docs/providers.md
@@ -1,0 +1,213 @@
+# Providers
+
+The card auto-detects a provider from the entity's attributes, so `provider:` is almost
+never needed. Any integration producing a compatible data shape will work — the table
+below lists the ones that are actually tested.
+
+| Provider | Region | Tested integrations |
+|----------|--------|---------------------|
+| NWS | US | [finity69x2/nws_alerts](https://github.com/finity69x2/nws_alerts) |
+| BoM | Australia | [bremor/bureau_of_meteorology](https://github.com/bremor/bureau_of_meteorology), [safepay/ha_bom_australia](https://github.com/safepay/ha_bom_australia) |
+| MeteoAlarm | Europe | Built-in [meteoalarm](https://www.home-assistant.io/integrations/meteoalarm/) |
+| DWD | Germany | Built-in [dwd_weather_warnings](https://www.home-assistant.io/integrations/dwd_weather_warnings/) |
+| MeteoSwiss | Switzerland | [izacus/hass-swissweather](https://github.com/izacus/hass-swissweather) |
+| ECCC | Canada | [seevee/cap_alerts](https://github.com/seevee/cap_alerts) (`provider: eccc`) — see [below](#canada-eccc-via-cap-alerts) |
+| NSW RFS | Australia (NSW) | Built-in [nsw_rural_fire_service_feed](https://www.home-assistant.io/integrations/nsw_rural_fire_service_feed/) |
+| PirateWeather | Global | [Pirate-Weather/pirate-weather-ha](https://github.com/Pirate-Weather/pirate-weather-ha) |
+| CAP Alerts | Multi-region | [seevee/cap_alerts](https://github.com/seevee/cap_alerts) |
+
+## How auto-detection works
+
+Each provider has an **adapter** that converts raw entity attributes into one normalized
+alert shape, which is all the card UI ever consumes. Detection is by attribute
+signature — NWS by its `Alerts` array, BoM by `warnings`, DWD by `warning_count` plus
+`region_name`, MeteoAlarm by its awareness-level attribute, PirateWeather by its
+attribution string, and so on.
+
+Set `provider:` explicitly only if you have a reason to override this.
+
+## Per-provider notes
+
+### NWS (US)
+
+```yaml
+type: custom:weather-alerts-card
+entity: sensor.nws_alerts_alerts
+```
+
+Severity and certainty both come straight from the feed. The recommended integration
+does **not** emit zone codes, so `zones` does not apply to it — use `eventCodes` to
+filter instead. Zone codes must be comma-delimited with **no spaces** when configuring
+the integration itself (`COC059,COZ039`); spaces make it silently return nothing.
+
+NWS descriptions arrive hard-wrapped at 69 characters, a teletype legacy. `reformatText`
+(on by default) strips those breaks while preserving real paragraphs.
+
+### BoM (Australia)
+
+```yaml
+type: custom:weather-alerts-card
+entity: sensor.sydney_warnings
+provider: bom
+```
+
+Cancelled warnings are filtered out. Severity is **inferred** from the warning type and
+group rather than provided — BoM carries no CAP severity field — so badges render with a
+tilde (`~Moderate`). Phase badges (New, Updated, Renewed) come from the feed's lifecycle
+field. `issue_time` is used as the onset, since BoM issues warnings when the threat is
+already imminent.
+
+`area_id` maps to `zones` for filtering, but only the `safepay/ha_bom_australia` fork
+emits it.
+
+### MeteoAlarm (Europe)
+
+```yaml
+type: custom:weather-alerts-card
+entity: binary_sensor.meteoalarm
+colorTheme: meteoalarm
+```
+
+The MeteoAlarm integration exposes a `binary_sensor` with flat attributes and returns
+**one alert per entity** — an upstream library limitation, not a card one. For full
+multi-alert European coverage, ingest the same feeds through
+[CAP Alerts](#cap-alerts-multi-region) instead.
+
+### DWD (Germany)
+
+```yaml
+type: custom:weather-alerts-card
+entity: sensor.dwd_weather_warnings_hamburg_current
+```
+
+DWD splits current and advance warnings across two sensors. Merge them:
+
+```yaml
+type: custom:weather-alerts-card
+entity: sensor.dwd_weather_warnings_current
+entities:
+  - sensor.dwd_weather_warnings_advance
+```
+
+### MeteoSwiss (Switzerland)
+
+```yaml
+type: custom:weather-alerts-card
+entity: sensor.weather_warnings_at_8000
+```
+
+Point the card at `sensor.weather_warnings_at_<postcode>`. Severity comes from an
+integer level; there is no certainty field.
+
+### NSW RFS (Australian bushfire)
+
+The `nsw_rural_fire_service_feed` integration creates one `geo_location.*` entity per
+active incident, and that set churns constantly as fires start and clear. Rather than
+hand-listing volatile entity ids, point the card at the feed:
+
+```yaml
+type: custom:weather-alerts-card
+sources:
+  - nsw_rural_fire_service_feed
+```
+
+`nsw_rural_fire_service_feed` is the `source` state attribute each incident entity
+carries, so the value maps one-to-one to what you see on the entity. In the visual
+editor this is the **Auto-collect from installed feeds** checkbox. You can still
+hand-list specific incidents under `entities:`, or group them with `device:`, for a
+fixed subset.
+
+Severity comes straight from the incident `category` — the Australian Warning System
+ladder (Emergency Warning / Watch and Act / Advice). Two consequences worth knowing:
+
+- Incidents have **no real expiry**, so the card shows an honest "ongoing" state with no
+  progress bar rather than inventing a countdown.
+- `showGeometry` is unavailable — the entity carries only a point, not the fire-ground
+  polygon.
+
+### PirateWeather
+
+```yaml
+type: custom:weather-alerts-card
+entity: sensor.pirateweather_alerts
+```
+
+### CAP Alerts (multi-region)
+
+The [CAP Alerts integration](https://github.com/seevee/cap_alerts) creates **one sensor
+per active alert** under a Home Assistant device. Point the card at the device and it
+picks up every active alert automatically, re-discovering them as alerts are issued and
+cleared:
+
+```yaml
+type: custom:weather-alerts-card
+device: 1a2b3c4d5e6f7a8b9c0d1e2f3a4b5c6d
+```
+
+Pick the device from the editor's CAP Alerts device selector rather than hand-typing the
+id. `device` can coexist with `entities:` for mixed setups.
+
+It ingests any CAP 1.2 feed — NWS, ECCC, MeteoAlarm, and the WMO Severe Weather
+Information Centre firehose for countries with no dedicated integration. Because it
+carries raw CAP fields and the original alert polygons, it is the only source that
+unlocks the `showGeometry` mini-map, and the only one with a per-alert entity for
+`tap_action: more-info` to target.
+
+## Canada: ECCC via CAP Alerts
+
+For Environment and Climate Change Canada alerts,
+[CAP Alerts](https://github.com/seevee/cap_alerts) (`provider: eccc`) is the source to
+use. It ingests the NAAD CAP firehose, creating one sensor per active alert under a
+device. That carries **raw** CAP severity and certainty, preserves the original
+multi-region polygons, and unlocks the affected-area mini-map.
+
+```yaml
+type: custom:weather-alerts-card
+device: 1a2b3c4d5e6f7a8b9c0d1e2f3a4b5c6d
+colorTheme: eccc      # ECCC's official red/orange/yellow/grey palette
+showGeometry: true    # affected-area mini-map
+```
+
+The provider auto-detects as `eccc`; set `provider: eccc` explicitly only if you have
+disabled auto-detection.
+
+### Why not the other ECCC integrations?
+
+Two others exist, and neither is the right source for this card.
+
+- **HA core `environment_canada`** exposes rich alert detail only through a `get_alerts`
+  **action** ([#172393](https://github.com/home-assistant/core/pull/172393), merged in
+  place of the attribute-based [#164481](https://github.com/home-assistant/core/pull/164481)).
+  A Lovelace card reads state and attributes during render and cannot consume an action
+  response, so core simply cannot drive this card.
+- The HACS **`environment_canada`** fork does surface alert attributes, but it is a
+  stop-gap its own maintainer would rather not keep running (see
+  [discussion #3130](https://github.com/orgs/home-assistant/discussions/3130)), and it
+  overrides the core integration's domain. Out of respect for that, ECCC users are not
+  routed to it.
+
+::: warning If you also run `environment_canada` for weather
+Its alert list (GeoMet WFS, filtered by a point-in-polygon test against your
+coordinates) will not line up with CAP Alerts' (NAAD CAP polygons, ingested directly).
+The WFS feed lags and truncates NAAD coverage, so an alert can appear in one and not the
+other. That is upstream behaviour, not the card.
+:::
+
+## Data fidelity
+
+Severity and certainty badges are always localized to your configured language. When a
+value was **inferred** by the card's adapter rather than provided by the source, it is
+rendered in italics with a tilde prefix (`~Moderate`) — so you can tell at a glance which
+badges reflect real provider data.
+
+| Provider | Severity | Certainty |
+|----------|----------|-----------|
+| NWS | Raw (from `Severity`) | Raw (from `Certainty`) |
+| BoM | Inferred (parsed from title/type/group) | Absent |
+| MeteoAlarm | Raw (from `awareness_level` or `severity`) | Raw (from `certainty`) |
+| DWD | Raw (from integer `level`) | Absent |
+| MeteoSwiss | Raw (from integer level) | Absent |
+| ECCC | Derived (max of `color`, `type`, `impact`; tilde only when all three are absent) | Mapped from `confidence` (High → Likely, Moderate → Possible, Low → Unlikely) |
+| NSW RFS | Raw (from `category`) | Absent |
+| PirateWeather | Raw (from `severity`) | Absent |
+| CAP Alerts | Raw (from `severity_normalized` / `severity`) | Raw (from `certainty`) |

--- a/docs/recipes/bubble-card-popup.md
+++ b/docs/recipes/bubble-card-popup.md
@@ -1,0 +1,80 @@
+# Bubble Card pop-up
+
+Send the compact layout's rows to a [Bubble Card](https://github.com/Clooos/Bubble-Card)
+pop-up instead of expanding them inline.
+
+::: tip Consider the built-in pop-up first
+[`tap_action: { action: details }`](./detail-popup) needs no add-ons and scopes to the
+tapped alert. Use this recipe when you specifically want Bubble's pop-up chrome, or when
+your dashboard is already built around it.
+:::
+
+![The compact card tapping through to a Bubble Card pop-up](/img/tap-action-adaptive.svg)
+
+## How it works
+
+`tap_action` navigates to the pop-up's hash; the second card *is* the pop-up, because
+Bubble listens for that hash and opens. Pair it with `hideNoAlerts` so the entry rows
+vanish when there is nothing to show.
+
+```yaml
+# 1) The entry rows: each row taps through to the shared pop-up
+type: custom:weather-alerts-card
+entity: sensor.nws_alerts_alerts
+provider: nws
+layout: compact
+hideNoAlerts: true
+tap_action:
+  action: navigate
+  navigation_path: '#weather-alerts'
+```
+
+```yaml
+# 2) The pop-up: one full-detail card behind the hash, listing every current alert
+type: custom:bubble-card
+card_type: pop-up
+hash: '#weather-alerts'
+card:
+  type: custom:weather-alerts-card
+  entity: sensor.nws_alerts_alerts
+  provider: nws
+  expandDetails: true
+```
+
+## Two things to know before wiring this up
+
+**The pop-up is shared, not per-alert.** A Bubble hash addresses one static pop-up, so
+every row navigates to the same one and it shows *all* current alerts in full detail —
+not only the alert you tapped. Per-alert scoping cannot be expressed with a hash; that is
+exactly what [`action: details`](./detail-popup) is for. To open the tapped alert's own
+HA entity dialog instead, use `tap_action: { action: more-info }`.
+
+**`layout: compact` renders one row per alert**, not a single summary chip. With three
+active alerts you get three entry rows, all tapping through to the same pop-up.
+
+## Making the card dissolve into the sheet
+
+By default the embedded card paints its own surface, so it stacks a second bordered box
+inside the pop-up. The [`--wac-*` tokens](../theming#surface-theming-wac-tokens) drive it
+transparent so it reads as part of the sheet:
+
+```yaml
+card_mod:
+  style: |
+    ha-card {
+      --wac-card-background: transparent;
+      --wac-alert-background: transparent;
+      --wac-alert-border: none;
+      --wac-alert-shadow: none;
+      --ha-card-box-shadow: none;
+    }
+```
+
+This is the same principle the figure above illustrates: one painted surface (the sheet),
+with the alert's severity shown as a single edge stripe rather than a perimeter frame.
+
+## browser_mod
+
+For a `browser_mod`-style pop-up, use
+`tap_action: { action: fire-dom-event, browser_mod: { ... } }` — the card fires the
+standard `ll-custom` event that `browser_mod` listens for.

--- a/docs/recipes/detail-popup.md
+++ b/docs/recipes/detail-popup.md
@@ -1,0 +1,58 @@
+# Per-alert detail pop-up
+
+**This is the recommended way to open alerts in a pop-up.** It is built into the card,
+needs no add-ons, and is genuinely per-alert for every provider.
+
+```yaml
+type: custom:weather-alerts-card
+entity: sensor.nws_alerts_alerts
+provider: nws
+layout: compact
+tap_action:
+  action: details
+```
+
+`tap_action: { action: details }` opens the tapped alert in a modal instead of expanding
+it in place. Works in both `layout: default` and `layout: compact`.
+
+## Why per-alert matters
+
+The card renders the alert object it already holds, so an **aggregate** sensor carrying
+five warnings still gives you five distinct pop-ups — one per row, each showing only
+that alert.
+
+This is the part hash-based pop-up recipes cannot do. A pop-up addressed by a URL hash
+is one static pop-up: every row navigates to the same one, so it can only ever show
+*all* current alerts. If you want the tapped alert, you want `action: details`.
+
+## What the pop-up shows
+
+The **whole alert** — icon, title, headline, area, badges, progress bar, metadata, and
+the full description and instructions.
+
+Because the pop-up *is* the detail view, the description is always open inside it; there
+is no "Read Details" toggle to click. The visibility options still apply:
+
+| Option | Applies in the pop-up? |
+|---|---|
+| `showDetails`, `showMetadata`, `showDescription`, `showInstructions`, `showGeometry` | Yes |
+| `expandDetails` | No — it governs the row only |
+
+## Notes
+
+- Setting any `tap_action` **replaces the inline expand affordance**: the whole row
+  becomes the tap target and the compact chevron / "Read Details" toggle is removed. In
+  `layout: default`, `expandDetails: true` still renders the always-on panel below the
+  row.
+- `details` is card-owned rather than a standard Home Assistant action — you will not
+  find it in HA's action documentation.
+- To open the tapped alert's own **HA entity dialog** instead, use
+  `tap_action: { action: more-info }`. On per-alert providers (CAP Alerts, NSW RFS) that
+  opens *that* alert's sensor; on aggregate providers it falls back to the aggregate
+  sensor.
+
+## Alternatives
+
+The [Bubble Card pop-up](./bubble-card-popup) recipe remains available, as does
+`browser_mod` via `fire-dom-event`. Prefer `action: details` unless you specifically want
+their pop-up chrome.

--- a/docs/theming.md
+++ b/docs/theming.md
@@ -1,0 +1,128 @@
+# Theming
+
+Two separate things are called "theming" here, and they are configured differently:
+
+- **Alert colors** — which palette maps a severity or an event code to a color. This is
+  a card option, `colorTheme`.
+- **Surfaces** — backgrounds, borders, corners, shadows, translucency. These are **not**
+  card options; they are CSS custom properties you set from theme YAML, card-mod, or a
+  dashboard `style:` block.
+
+## Color themes
+
+![The severity, NWS and MeteoAlarm color themes side by side](/img/themes-adaptive.svg)
+
+| `colorTheme` | Palette |
+|---|---|
+| `'severity'` *(default)* | The card's own severity ladder — extreme, severe, moderate, minor, unknown |
+| `'nws'` | The National Weather Service's official per-event colors |
+| `'meteoalarm'` | MeteoAlarm awareness-level colors |
+| `'eccc'` | ECCC's published red / orange / yellow / grey palette, matching weather.gc.ca |
+
+`'severity'` is provider-agnostic and always works. The other three are agency palettes:
+they key off event codes or awareness levels that only some providers emit, and fall
+back to the canonical severity tier for alerts they do not recognize. `'eccc'`, for
+instance, renders a non-ECCC alert by severity rather than inventing a color for it.
+
+Agency palettes were designed for print and for maps, so a few of their colors read
+poorly on a dashboard card in one theme mode or the other. `enhanceContrast` corrects
+this per event and per mode — see
+[the configuration reference](./configuration#enhancecontrast).
+
+## Surface theming (`--wac-*` tokens)
+
+The card exposes a small, stable set of CSS custom properties for its surfaces. Unset,
+every token falls back to the value the card has always used, so the default look is
+unchanged.
+
+The outer `<ha-card>` is the **single painted surface**; each alert box defaults to a
+transparent fill and reveals it. That means a translucent theme
+(`--ha-card-background: rgba(...)`) renders its alpha exactly once, instead of
+compounding into a "solid" look on the alert bodies. The standard
+`--ha-card-background`, `--ha-card-border-radius` and `--ha-card-box-shadow` also work
+as expected.
+
+| Token | Default | Controls |
+|-------|---------|----------|
+| `--wac-card-background` | `var(--ha-card-background, var(--card-background-color))` | Outer card wrapper fill |
+| `--wac-alert-background` | `transparent` | Per-alert box fill (reveals the outer surface) |
+| `--wac-alert-border-radius` | `12px` (full) / `8px` (compact) | Per-alert corner radius |
+| `--wac-alert-border` | `1px solid var(--divider-color)` | Per-alert border |
+| `--wac-alert-shadow` | `var(--ha-card-box-shadow, 0 2px 5px rgba(0,0,0,0.1))` | Per-alert shadow |
+| `--wac-alert-gap` | `16px` (full) / `4px` (compact) | Vertical gap between alerts |
+| `--wac-progress-fill-color` | `var(--wac-progress-fg)` | Wash color for `progressFill: background` |
+| `--wac-progress-fill-opacity` | `0.10` (light) / `0.14` (dark) | Wash strength |
+| `--wac-progress-fill-expired-opacity` | `0.06` | Dimmer wash for expired rows |
+
+![A translucent-surface card and a pill/chip card, both built from the --wac-* tokens](/img/surface-theming-adaptive.svg)
+
+*Left: a translucent theme — the alert bodies stay transparent, so the surface alpha
+lands once. Right: a pill/chip look — a transparent wrapper with filled boxes. Both come
+from the examples below.*
+
+The progress-fill tokens inherit the severity color and its contrast boost. Their
+opacity is deliberately low: the wash sits **behind** alert text, and a stronger tint
+costs legibility. Tune it down, or to `0`, rather than up.
+
+## Examples
+
+These use [card-mod](https://github.com/thomasloven/lovelace-card-mod) for a per-card
+override. The same properties work in theme YAML if you want them applied globally.
+
+### Translucent theme
+
+Set a translucent card background and let the alert boxes inherit it. This is already
+the default behaviour; it is spelled out here as a per-card override.
+
+```yaml
+type: custom:weather-alerts-card
+entity: sensor.nws_alerts_alerts
+provider: nws
+card_mod:
+  style: |
+    ha-card {
+      --ha-card-background: rgba(40, 40, 40, 0.6);
+      --wac-alert-background: transparent; /* default; alert bodies stay translucent */
+    }
+```
+
+### Pill / chip look
+
+Filled alert boxes on a transparent wrapper, approximating a
+[Bubble Card](https://github.com/Clooos/Bubble-Card) style. Contributed in
+[#144](https://github.com/seevee/weather_alerts_card/issues/144).
+
+```yaml
+type: custom:weather-alerts-card
+entity: sensor.nws_alerts_alerts
+sortOrder: severity
+layout: compact
+provider: nws
+card_mod:
+  style: |
+    ha-card {
+      --wac-card-background: transparent;
+      --ha-card-box-shadow: none; /* flatten the now-invisible outer wrapper */
+      --wac-alert-background: rgb(40, 40, 40);
+      --wac-alert-border: none;
+      --wac-alert-border-radius: 28px;
+      --wac-alert-shadow: none;
+      --wac-alert-gap: 8px;
+    }
+```
+
+Note `--ha-card-box-shadow: none` alongside the tokens: with a transparent
+`--wac-card-background`, the outer `<ha-card>` would otherwise still cast its own shadow
+around the now-invisible wrapper.
+
+::: warning This snippet is dark-mode only
+`rgb(40, 40, 40)` is a hardcoded dark fill — it will look wrong under a light theme. Use
+`var(--card-background-color)`, or a `prefers-color-scheme` pair, if you switch modes.
+:::
+
+## What is not a public API
+
+Deeper layout tweaks — row height, icon chip size — still require reaching into the
+card's internal class names. Those are **not** a stable interface and may change between
+releases without a major version bump. Prefer the tokens above wherever they suffice,
+and open an issue if something you need has no token.

--- a/package-lock.json
+++ b/package-lock.json
@@ -30,7 +30,266 @@
         "rollup-plugin-typescript2": "^0.37.0",
         "semver": "^7.7.4",
         "typescript": "^6.0.3",
+        "vitepress": "^1.6.4",
         "vitest": "^4.0.18"
+      }
+    },
+    "node_modules/@algolia/abtesting": {
+      "version": "1.22.0",
+      "resolved": "https://registry.npmjs.org/@algolia/abtesting/-/abtesting-1.22.0.tgz",
+      "integrity": "sha512-BFR6zNowNKcY7Ou7TaJc9QWexES4YKPbmf/OTFofpdsdhz4x6q0lbxp3duO0EHnyrN7rE4ba/TSXuY+BDGu4+g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@algolia/client-common": "5.56.0",
+        "@algolia/requester-browser-xhr": "5.56.0",
+        "@algolia/requester-fetch": "5.56.0",
+        "@algolia/requester-node-http": "5.56.0"
+      },
+      "engines": {
+        "node": ">= 14.0.0"
+      }
+    },
+    "node_modules/@algolia/autocomplete-core": {
+      "version": "1.17.7",
+      "resolved": "https://registry.npmjs.org/@algolia/autocomplete-core/-/autocomplete-core-1.17.7.tgz",
+      "integrity": "sha512-BjiPOW6ks90UKl7TwMv7oNQMnzU+t/wk9mgIDi6b1tXpUek7MW0lbNOUHpvam9pe3lVCf4xPFT+lK7s+e+fs7Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@algolia/autocomplete-plugin-algolia-insights": "1.17.7",
+        "@algolia/autocomplete-shared": "1.17.7"
+      }
+    },
+    "node_modules/@algolia/autocomplete-plugin-algolia-insights": {
+      "version": "1.17.7",
+      "resolved": "https://registry.npmjs.org/@algolia/autocomplete-plugin-algolia-insights/-/autocomplete-plugin-algolia-insights-1.17.7.tgz",
+      "integrity": "sha512-Jca5Ude6yUOuyzjnz57og7Et3aXjbwCSDf/8onLHSQgw1qW3ALl9mrMWaXb5FmPVkV3EtkD2F/+NkT6VHyPu9A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@algolia/autocomplete-shared": "1.17.7"
+      },
+      "peerDependencies": {
+        "search-insights": ">= 1 < 3"
+      }
+    },
+    "node_modules/@algolia/autocomplete-preset-algolia": {
+      "version": "1.17.7",
+      "resolved": "https://registry.npmjs.org/@algolia/autocomplete-preset-algolia/-/autocomplete-preset-algolia-1.17.7.tgz",
+      "integrity": "sha512-ggOQ950+nwbWROq2MOCIL71RE0DdQZsceqrg32UqnhDz8FlO9rL8ONHNsI2R1MH0tkgVIDKI/D0sMiUchsFdWA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@algolia/autocomplete-shared": "1.17.7"
+      },
+      "peerDependencies": {
+        "@algolia/client-search": ">= 4.9.1 < 6",
+        "algoliasearch": ">= 4.9.1 < 6"
+      }
+    },
+    "node_modules/@algolia/autocomplete-shared": {
+      "version": "1.17.7",
+      "resolved": "https://registry.npmjs.org/@algolia/autocomplete-shared/-/autocomplete-shared-1.17.7.tgz",
+      "integrity": "sha512-o/1Vurr42U/qskRSuhBH+VKxMvkkUVTLU6WZQr+L5lGZZLYWyhdzWjW0iGXY7EkwRTjBqvN2EsR81yCTGV/kmg==",
+      "dev": true,
+      "license": "MIT",
+      "peerDependencies": {
+        "@algolia/client-search": ">= 4.9.1 < 6",
+        "algoliasearch": ">= 4.9.1 < 6"
+      }
+    },
+    "node_modules/@algolia/client-abtesting": {
+      "version": "5.56.0",
+      "resolved": "https://registry.npmjs.org/@algolia/client-abtesting/-/client-abtesting-5.56.0.tgz",
+      "integrity": "sha512-7r4Z3NC7yU1oAQVWJNA2HX7tX481F3pJvCGyLIXiTdBcthz4Q/o21jwcMYDFkuI92UWTNBQQmHYgwHo1zS5dzg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@algolia/client-common": "5.56.0",
+        "@algolia/requester-browser-xhr": "5.56.0",
+        "@algolia/requester-fetch": "5.56.0",
+        "@algolia/requester-node-http": "5.56.0"
+      },
+      "engines": {
+        "node": ">= 14.0.0"
+      }
+    },
+    "node_modules/@algolia/client-analytics": {
+      "version": "5.56.0",
+      "resolved": "https://registry.npmjs.org/@algolia/client-analytics/-/client-analytics-5.56.0.tgz",
+      "integrity": "sha512-avmjXQSq+jadFO8Xl2em05/uQdQnEmHsJyOAdVbZkmVgpMfxL12aJwVVfGNwYr9nulcpuJN1X0lTaQ5wxuNGcA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@algolia/client-common": "5.56.0",
+        "@algolia/requester-browser-xhr": "5.56.0",
+        "@algolia/requester-fetch": "5.56.0",
+        "@algolia/requester-node-http": "5.56.0"
+      },
+      "engines": {
+        "node": ">= 14.0.0"
+      }
+    },
+    "node_modules/@algolia/client-common": {
+      "version": "5.56.0",
+      "resolved": "https://registry.npmjs.org/@algolia/client-common/-/client-common-5.56.0.tgz",
+      "integrity": "sha512-v2TPStUhY//ripPjIVclZ8AWc7DEGooXULZGFlFu37zNatgHjw34oZZ+OSbbc/YHO+xZwPl62I1k8xH1m4S2eg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 14.0.0"
+      }
+    },
+    "node_modules/@algolia/client-insights": {
+      "version": "5.56.0",
+      "resolved": "https://registry.npmjs.org/@algolia/client-insights/-/client-insights-5.56.0.tgz",
+      "integrity": "sha512-P0ehROpM4Sem3Sqo5x2cKPgj67D3G3jy0rh1Amwkcvsfr6tkvIcdCmerieanqTF7NxUMPNFLkpIFeMO8Rpa50w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@algolia/client-common": "5.56.0",
+        "@algolia/requester-browser-xhr": "5.56.0",
+        "@algolia/requester-fetch": "5.56.0",
+        "@algolia/requester-node-http": "5.56.0"
+      },
+      "engines": {
+        "node": ">= 14.0.0"
+      }
+    },
+    "node_modules/@algolia/client-personalization": {
+      "version": "5.56.0",
+      "resolved": "https://registry.npmjs.org/@algolia/client-personalization/-/client-personalization-5.56.0.tgz",
+      "integrity": "sha512-SXK3Vn3WVxyzbm31oePZBJkp1wpOyuWdd4B/Pv7n0aXDxmeSWhC1R1FC1517mMrFAIaPH4Rt0x6RUe7ZNjz8FA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@algolia/client-common": "5.56.0",
+        "@algolia/requester-browser-xhr": "5.56.0",
+        "@algolia/requester-fetch": "5.56.0",
+        "@algolia/requester-node-http": "5.56.0"
+      },
+      "engines": {
+        "node": ">= 14.0.0"
+      }
+    },
+    "node_modules/@algolia/client-query-suggestions": {
+      "version": "5.56.0",
+      "resolved": "https://registry.npmjs.org/@algolia/client-query-suggestions/-/client-query-suggestions-5.56.0.tgz",
+      "integrity": "sha512-5+ZdX8garFnmycnZgKhtXHePEaLj5zqDxI/0lkhhluzCcvTn0/PvvTirTg8hHYetQHvn7GDyeAiqTAieMvMW4A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@algolia/client-common": "5.56.0",
+        "@algolia/requester-browser-xhr": "5.56.0",
+        "@algolia/requester-fetch": "5.56.0",
+        "@algolia/requester-node-http": "5.56.0"
+      },
+      "engines": {
+        "node": ">= 14.0.0"
+      }
+    },
+    "node_modules/@algolia/client-search": {
+      "version": "5.56.0",
+      "resolved": "https://registry.npmjs.org/@algolia/client-search/-/client-search-5.56.0.tgz",
+      "integrity": "sha512-+mKUdYvqOi0BcvpAEyCEw49vSBptufIcfibtHz2bdr1pI789M46Yt0uQEk/sxtK3teh71OQvVFHaTDzShUWewQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@algolia/client-common": "5.56.0",
+        "@algolia/requester-browser-xhr": "5.56.0",
+        "@algolia/requester-fetch": "5.56.0",
+        "@algolia/requester-node-http": "5.56.0"
+      },
+      "engines": {
+        "node": ">= 14.0.0"
+      }
+    },
+    "node_modules/@algolia/ingestion": {
+      "version": "1.56.0",
+      "resolved": "https://registry.npmjs.org/@algolia/ingestion/-/ingestion-1.56.0.tgz",
+      "integrity": "sha512-9g/zj+AZx5moFcdFIrYQoVrueXivjUcc3MQHtCYT8WhIuk1lUh1AyEhvJCS0XBZld09cLvd1AZ3BvDBpVpX2UA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@algolia/client-common": "5.56.0",
+        "@algolia/requester-browser-xhr": "5.56.0",
+        "@algolia/requester-fetch": "5.56.0",
+        "@algolia/requester-node-http": "5.56.0"
+      },
+      "engines": {
+        "node": ">= 14.0.0"
+      }
+    },
+    "node_modules/@algolia/monitoring": {
+      "version": "1.56.0",
+      "resolved": "https://registry.npmjs.org/@algolia/monitoring/-/monitoring-1.56.0.tgz",
+      "integrity": "sha512-Qf3Sr6f9A9uxCZUf3MXS0d2b877uYzEB5yxqpVGXAhcJnBCQjrRRon0KvefpGkxy+BshrIJs96OUoMtGqXTFDA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@algolia/client-common": "5.56.0",
+        "@algolia/requester-browser-xhr": "5.56.0",
+        "@algolia/requester-fetch": "5.56.0",
+        "@algolia/requester-node-http": "5.56.0"
+      },
+      "engines": {
+        "node": ">= 14.0.0"
+      }
+    },
+    "node_modules/@algolia/recommend": {
+      "version": "5.56.0",
+      "resolved": "https://registry.npmjs.org/@algolia/recommend/-/recommend-5.56.0.tgz",
+      "integrity": "sha512-GXWG1rWc5wu8hY4N33Y3b6ernY6sAdAvmKWN/zHAiACOx40WnpG0TVX5YazCAr/9gOYGInSiM2A0y2jy2xbiDA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@algolia/client-common": "5.56.0",
+        "@algolia/requester-browser-xhr": "5.56.0",
+        "@algolia/requester-fetch": "5.56.0",
+        "@algolia/requester-node-http": "5.56.0"
+      },
+      "engines": {
+        "node": ">= 14.0.0"
+      }
+    },
+    "node_modules/@algolia/requester-browser-xhr": {
+      "version": "5.56.0",
+      "resolved": "https://registry.npmjs.org/@algolia/requester-browser-xhr/-/requester-browser-xhr-5.56.0.tgz",
+      "integrity": "sha512-7t24cBxaInS3mZb7ddEaZT/tp6q+/aR4YttsQVyP1/i+LmwPR34atO35KjaLFCcRVrlP7sYOAqkCfg6lIRB+ew==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@algolia/client-common": "5.56.0"
+      },
+      "engines": {
+        "node": ">= 14.0.0"
+      }
+    },
+    "node_modules/@algolia/requester-fetch": {
+      "version": "5.56.0",
+      "resolved": "https://registry.npmjs.org/@algolia/requester-fetch/-/requester-fetch-5.56.0.tgz",
+      "integrity": "sha512-R7ePHgVYmDFjZpvrsVAfbDz/d4RxKAYZ5/vgLfIsCVRZRryjWl/3INOxpOICzitehQ5FjNtNjcLQTrmHPTcHBQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@algolia/client-common": "5.56.0"
+      },
+      "engines": {
+        "node": ">= 14.0.0"
+      }
+    },
+    "node_modules/@algolia/requester-node-http": {
+      "version": "5.56.0",
+      "resolved": "https://registry.npmjs.org/@algolia/requester-node-http/-/requester-node-http-5.56.0.tgz",
+      "integrity": "sha512-PIOUXlSnrqM0S+WOgDRb4RzotydJH7ZoT6tOyL7tAO7qJOfvX5wsEW8Pe+PMKMwvuI4/gIyK9cg2H7lJXqnc4Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@algolia/client-common": "5.56.0"
+      },
+      "engines": {
+        "node": ">= 14.0.0"
       }
     },
     "node_modules/@asamuzakjp/css-color": {
@@ -99,12 +358,52 @@
         "node": ">=6.9.0"
       }
     },
-    "node_modules/@babel/helper-validator-identifier": {
-      "version": "7.28.5",
-      "resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.28.5.tgz",
-      "integrity": "sha512-qSs4ifwzKJSV39ucNjsvc6WVHs6b7S03sOh2OcHF9UHfVPqWWALUsNUVzhSBiItjRZoLHx7nIarVjqKVusUZ1Q==",
+    "node_modules/@babel/helper-string-parser": {
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/helper-string-parser/-/helper-string-parser-7.29.7.tgz",
+      "integrity": "sha512-Pb5ijPrZ89GDH8223L4UP8i6QApWxs04RbPQJTeWDV0/keR2E36MeKnyr6LYmUUvqRRI+Iv87SuF1W6ErINzYw==",
       "dev": true,
       "license": "MIT",
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/helper-validator-identifier": {
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.29.7.tgz",
+      "integrity": "sha512-qehxGkRj55h/ff8EMaJ+cYhyaKlHIxqYDn682wQD7RNp9UujOQsHog2uS0r2vzr4pW+sXf90NeeayjcNaX3fFg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/parser": {
+      "version": "7.29.8",
+      "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.29.8.tgz",
+      "integrity": "sha512-E8lTAYNB1KW+FH+VGJuZM1ioAx2E6oVlvQFRrf5P8ZZmsiJXYAD9vTFV7yyEURNzgh1dFqMZuO6tUwcARbqFCA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/types": "^7.29.8"
+      },
+      "bin": {
+        "parser": "bin/babel-parser.js"
+      },
+      "engines": {
+        "node": ">=6.0.0"
+      }
+    },
+    "node_modules/@babel/types": {
+      "version": "7.29.8",
+      "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.29.8.tgz",
+      "integrity": "sha512-Vj1jF3cPfxg7OAfoI7QnVKLoILlm2JF9pnVHrX8qx7AHMiYWT+NDAA7jChlNgRS4WTLc/fD1lXLmPixluj+3Gg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-string-parser": "^7.29.7",
+        "@babel/helper-validator-identifier": "^7.29.7"
+      },
       "engines": {
         "node": ">=6.9.0"
       }
@@ -294,6 +593,57 @@
       "license": "MIT",
       "engines": {
         "node": ">=20.19.0"
+      }
+    },
+    "node_modules/@docsearch/css": {
+      "version": "3.8.2",
+      "resolved": "https://registry.npmjs.org/@docsearch/css/-/css-3.8.2.tgz",
+      "integrity": "sha512-y05ayQFyUmCXze79+56v/4HpycYF3uFqB78pLPrSV5ZKAlDuIAAJNhaRi8tTdRNXh05yxX/TyNnzD6LwSM89vQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@docsearch/js": {
+      "version": "3.8.2",
+      "resolved": "https://registry.npmjs.org/@docsearch/js/-/js-3.8.2.tgz",
+      "integrity": "sha512-Q5wY66qHn0SwA7Taa0aDbHiJvaFJLOJyHmooQ7y8hlwwQLQ/5WwCcoX0g7ii04Qi2DJlHsd0XXzJ8Ypw9+9YmQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@docsearch/react": "3.8.2",
+        "preact": "^10.0.0"
+      }
+    },
+    "node_modules/@docsearch/react": {
+      "version": "3.8.2",
+      "resolved": "https://registry.npmjs.org/@docsearch/react/-/react-3.8.2.tgz",
+      "integrity": "sha512-xCRrJQlTt8N9GU0DG4ptwHRkfnSnD/YpdeaXe02iKfqs97TkZJv60yE+1eq/tjPcVnTW8dP5qLP7itifFVV5eg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@algolia/autocomplete-core": "1.17.7",
+        "@algolia/autocomplete-preset-algolia": "1.17.7",
+        "@docsearch/css": "3.8.2",
+        "algoliasearch": "^5.14.2"
+      },
+      "peerDependencies": {
+        "@types/react": ">= 16.8.0 < 19.0.0",
+        "react": ">= 16.8.0 < 19.0.0",
+        "react-dom": ">= 16.8.0 < 19.0.0",
+        "search-insights": ">= 1 < 3"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "react": {
+          "optional": true
+        },
+        "react-dom": {
+          "optional": true
+        },
+        "search-insights": {
+          "optional": true
+        }
       }
     },
     "node_modules/@emnapi/core": {
@@ -825,6 +1175,23 @@
       "engines": {
         "node": ">=10.13.0"
       }
+    },
+    "node_modules/@iconify-json/simple-icons": {
+      "version": "1.2.93",
+      "resolved": "https://registry.npmjs.org/@iconify-json/simple-icons/-/simple-icons-1.2.93.tgz",
+      "integrity": "sha512-/XhANjfGYOuqvSR3TmUnkQkINvQ4GVjVuukvymRbxtVFBvIq/yiXJqCDycKcQPT401OYT9H2vIY6ihAlz1QIAw==",
+      "dev": true,
+      "license": "CC0-1.0",
+      "dependencies": {
+        "@iconify/types": "*"
+      }
+    },
+    "node_modules/@iconify/types": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/@iconify/types/-/types-2.0.0.tgz",
+      "integrity": "sha512-+wluvCrRhXrhyOmRDJ3q8mux9JkKy5SJ/v8ol2tu4FVjyYvtEzkc/3pK15ET6RKg4b4w4BmTk1+gsCUhf21Ykg==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/@jridgewell/sourcemap-codec": {
       "version": "1.5.5",
@@ -1666,6 +2033,93 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/@shikijs/core": {
+      "version": "2.5.0",
+      "resolved": "https://registry.npmjs.org/@shikijs/core/-/core-2.5.0.tgz",
+      "integrity": "sha512-uu/8RExTKtavlpH7XqnVYBrfBkUc20ngXiX9NSrBhOVZYv/7XQRKUyhtkeflY5QsxC0GbJThCerruZfsUaSldg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@shikijs/engine-javascript": "2.5.0",
+        "@shikijs/engine-oniguruma": "2.5.0",
+        "@shikijs/types": "2.5.0",
+        "@shikijs/vscode-textmate": "^10.0.2",
+        "@types/hast": "^3.0.4",
+        "hast-util-to-html": "^9.0.4"
+      }
+    },
+    "node_modules/@shikijs/engine-javascript": {
+      "version": "2.5.0",
+      "resolved": "https://registry.npmjs.org/@shikijs/engine-javascript/-/engine-javascript-2.5.0.tgz",
+      "integrity": "sha512-VjnOpnQf8WuCEZtNUdjjwGUbtAVKuZkVQ/5cHy/tojVVRIRtlWMYVjyWhxOmIq05AlSOv72z7hRNRGVBgQOl0w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@shikijs/types": "2.5.0",
+        "@shikijs/vscode-textmate": "^10.0.2",
+        "oniguruma-to-es": "^3.1.0"
+      }
+    },
+    "node_modules/@shikijs/engine-oniguruma": {
+      "version": "2.5.0",
+      "resolved": "https://registry.npmjs.org/@shikijs/engine-oniguruma/-/engine-oniguruma-2.5.0.tgz",
+      "integrity": "sha512-pGd1wRATzbo/uatrCIILlAdFVKdxImWJGQ5rFiB5VZi2ve5xj3Ax9jny8QvkaV93btQEwR/rSz5ERFpC5mKNIw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@shikijs/types": "2.5.0",
+        "@shikijs/vscode-textmate": "^10.0.2"
+      }
+    },
+    "node_modules/@shikijs/langs": {
+      "version": "2.5.0",
+      "resolved": "https://registry.npmjs.org/@shikijs/langs/-/langs-2.5.0.tgz",
+      "integrity": "sha512-Qfrrt5OsNH5R+5tJ/3uYBBZv3SuGmnRPejV9IlIbFH3HTGLDlkqgHymAlzklVmKBjAaVmkPkyikAV/sQ1wSL+w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@shikijs/types": "2.5.0"
+      }
+    },
+    "node_modules/@shikijs/themes": {
+      "version": "2.5.0",
+      "resolved": "https://registry.npmjs.org/@shikijs/themes/-/themes-2.5.0.tgz",
+      "integrity": "sha512-wGrk+R8tJnO0VMzmUExHR+QdSaPUl/NKs+a4cQQRWyoc3YFbUzuLEi/KWK1hj+8BfHRKm2jNhhJck1dfstJpiw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@shikijs/types": "2.5.0"
+      }
+    },
+    "node_modules/@shikijs/transformers": {
+      "version": "2.5.0",
+      "resolved": "https://registry.npmjs.org/@shikijs/transformers/-/transformers-2.5.0.tgz",
+      "integrity": "sha512-SI494W5X60CaUwgi8u4q4m4s3YAFSxln3tzNjOSYqq54wlVgz0/NbbXEb3mdLbqMBztcmS7bVTaEd2w0qMmfeg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@shikijs/core": "2.5.0",
+        "@shikijs/types": "2.5.0"
+      }
+    },
+    "node_modules/@shikijs/types": {
+      "version": "2.5.0",
+      "resolved": "https://registry.npmjs.org/@shikijs/types/-/types-2.5.0.tgz",
+      "integrity": "sha512-ygl5yhxki9ZLNuNpPitBWvcy9fsSKKaRuO4BAlMyagszQidxcpLAr0qiW/q43DtSIDxO6hEbtYLiFZNXO/hdGw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@shikijs/vscode-textmate": "^10.0.2",
+        "@types/hast": "^3.0.4"
+      }
+    },
+    "node_modules/@shikijs/vscode-textmate": {
+      "version": "10.0.2",
+      "resolved": "https://registry.npmjs.org/@shikijs/vscode-textmate/-/vscode-textmate-10.0.2.tgz",
+      "integrity": "sha512-83yeghZ2xxin3Nj8z1NMd/NCuca+gsYXswywDy5bHvwlWL8tpTQmzGeUuHd9FC3E/SBEMvzJRwWEOz5gGes9Qg==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/@simple-libs/child-process-utils": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/@simple-libs/child-process-utils/-/child-process-utils-1.0.2.tgz",
@@ -1761,6 +2215,51 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/@types/hast": {
+      "version": "3.0.5",
+      "resolved": "https://registry.npmjs.org/@types/hast/-/hast-3.0.5.tgz",
+      "integrity": "sha512-rp/ezSWaD1m44dPKICGhiskI13nVr7qTloFwDa/IYkhhf5nzwP+zIQcIJh3WIFSBOy/H1PzB40jPjMDksN4F+g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/unist": "*"
+      }
+    },
+    "node_modules/@types/linkify-it": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/@types/linkify-it/-/linkify-it-5.0.0.tgz",
+      "integrity": "sha512-sVDA58zAw4eWAffKOaQH5/5j3XeayukzDk+ewSsnv3p4yJEZHCCzMDiZM8e0OUrRvmpGZ85jf4yDHkHsgBNr9Q==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@types/markdown-it": {
+      "version": "14.1.2",
+      "resolved": "https://registry.npmjs.org/@types/markdown-it/-/markdown-it-14.1.2.tgz",
+      "integrity": "sha512-promo4eFwuiW+TfGxhi+0x3czqTYJkG8qB17ZUJiVF10Xm7NLVRSLUsfRTU/6h1e24VvRnXCx+hG7li58lkzog==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/linkify-it": "^5",
+        "@types/mdurl": "^2"
+      }
+    },
+    "node_modules/@types/mdast": {
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/@types/mdast/-/mdast-4.0.4.tgz",
+      "integrity": "sha512-kGaNbPh1k7AFzgpud/gMdvIm5xuECykRR+JnWKQno9TAXVa6WIVCGTPvYGekIDL4uwCZQSYbUxNBSb1aUo79oA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/unist": "*"
+      }
+    },
+    "node_modules/@types/mdurl": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/@types/mdurl/-/mdurl-2.0.0.tgz",
+      "integrity": "sha512-RGdgjQUZba5p6QEFAVx2OGb8rQDL/cPRG7GiedRzMcJ1tYnUANBncjbSB1NRGwbvjcPeikRABz2nshyPk1bhWg==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/@types/normalize-package-data": {
       "version": "2.4.4",
       "resolved": "https://registry.npmjs.org/@types/normalize-package-data/-/normalize-package-data-2.4.4.tgz",
@@ -1780,6 +2279,27 @@
       "resolved": "https://registry.npmjs.org/@types/trusted-types/-/trusted-types-2.0.7.tgz",
       "integrity": "sha512-ScaPdn1dQczgbl0QFTeTOmVHFULt394XJgOQNoyVhZ6r2vLnMLJfBPd53SB52T/3G36VI1/g2MZaX0cwDuXsfw==",
       "license": "MIT"
+    },
+    "node_modules/@types/unist": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/@types/unist/-/unist-3.0.3.tgz",
+      "integrity": "sha512-ko/gIFJRv177XgZsZcBwnqJN5x/Gien8qNOn0D5bQU/zAzVf9Zt3BlcUiLqhV9y4ARk0GbT3tnUiPNgnTXzc/Q==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@types/web-bluetooth": {
+      "version": "0.0.21",
+      "resolved": "https://registry.npmjs.org/@types/web-bluetooth/-/web-bluetooth-0.0.21.tgz",
+      "integrity": "sha512-oIQLCGWtcFZy2JW77j9k8nHzAOpqMHLQejDA48XXMWH6tjCQHz5RCFz1bzsmROyL6PUm+LLnUiI4BCn221inxA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@ungap/structured-clone": {
+      "version": "1.3.3",
+      "resolved": "https://registry.npmjs.org/@ungap/structured-clone/-/structured-clone-1.3.3.tgz",
+      "integrity": "sha512-60YRaenCQcVjYEKOcG824+DRGGIQ3VKErcBoAEDJZz5bKIs2ZG+X/H9Nk+Q6EVkwJk5QNApxbrc5QtBSwtrXAg==",
+      "dev": true,
+      "license": "ISC"
     },
     "node_modules/@vitest/browser": {
       "version": "4.1.6",
@@ -1927,12 +2447,300 @@
         "url": "https://opencollective.com/vitest"
       }
     },
+    "node_modules/@vue/compiler-core": {
+      "version": "3.5.40",
+      "resolved": "https://registry.npmjs.org/@vue/compiler-core/-/compiler-core-3.5.40.tgz",
+      "integrity": "sha512-39E8IgOhTbVDnoJFMKc2DvYnypcZwUqgUhQkccva/0m6FUwtIKSGV7n1hpVmYcFaoRAwf9pBcwnKlCEsN63ZEQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/parser": "^7.29.7",
+        "@vue/shared": "3.5.40",
+        "entities": "^7.0.1",
+        "estree-walker": "^2.0.2",
+        "source-map-js": "^1.2.1"
+      }
+    },
+    "node_modules/@vue/compiler-core/node_modules/entities": {
+      "version": "7.0.1",
+      "resolved": "https://registry.npmjs.org/entities/-/entities-7.0.1.tgz",
+      "integrity": "sha512-TWrgLOFUQTH994YUyl1yT4uyavY5nNB5muff+RtWaqNVCAK408b5ZnnbNAUEWLTCpum9w6arT70i1XdQ4UeOPA==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=0.12"
+      },
+      "funding": {
+        "url": "https://github.com/fb55/entities?sponsor=1"
+      }
+    },
+    "node_modules/@vue/compiler-dom": {
+      "version": "3.5.40",
+      "resolved": "https://registry.npmjs.org/@vue/compiler-dom/-/compiler-dom-3.5.40.tgz",
+      "integrity": "sha512-pwkx4vqlqOspFstrcmzwkKLePVMD3PT65imRzLhanU2V1Fj4K13g6OXjanOyzw3aTAuRk84BOmY8f3rEHqPaVA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vue/compiler-core": "3.5.40",
+        "@vue/shared": "3.5.40"
+      }
+    },
+    "node_modules/@vue/compiler-sfc": {
+      "version": "3.5.40",
+      "resolved": "https://registry.npmjs.org/@vue/compiler-sfc/-/compiler-sfc-3.5.40.tgz",
+      "integrity": "sha512-gIf497P4kpuALcvs5n3AEg1Vdn0pSY4XbjASIfHNYF1/MP3T2Mf2STERTubysBxCRxzJGJYtF/O7vwJrxFB3Vw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/parser": "^7.29.7",
+        "@vue/compiler-core": "3.5.40",
+        "@vue/compiler-dom": "3.5.40",
+        "@vue/compiler-ssr": "3.5.40",
+        "@vue/shared": "3.5.40",
+        "estree-walker": "^2.0.2",
+        "magic-string": "^0.30.21",
+        "postcss": "^8.5.19",
+        "source-map-js": "^1.2.1"
+      }
+    },
+    "node_modules/@vue/compiler-ssr": {
+      "version": "3.5.40",
+      "resolved": "https://registry.npmjs.org/@vue/compiler-ssr/-/compiler-ssr-3.5.40.tgz",
+      "integrity": "sha512-rrE5xiXG663+vHCHa3J9p2z5OcBRjXmoqenprJxAFQxg5pSshzeBiCE6pu46axapRJ2Adk0YDA2BRZVjiHXnhg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vue/compiler-dom": "3.5.40",
+        "@vue/shared": "3.5.40"
+      }
+    },
+    "node_modules/@vue/devtools-api": {
+      "version": "7.7.10",
+      "resolved": "https://registry.npmjs.org/@vue/devtools-api/-/devtools-api-7.7.10.tgz",
+      "integrity": "sha512-KxtEpUOOpFz/qOGRrAwA36QF7DqIA+FXgCYit9mk9wjbaZt0sXOFz81ElOZtKA4HbWHUdwNjZHBFsFFyp5BZiA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vue/devtools-kit": "^7.7.10"
+      }
+    },
+    "node_modules/@vue/devtools-kit": {
+      "version": "7.7.10",
+      "resolved": "https://registry.npmjs.org/@vue/devtools-kit/-/devtools-kit-7.7.10.tgz",
+      "integrity": "sha512-3WNi2Kq4tbpVbmhml7RiphmAt0279oh3fKNeWMQIrltfX8Q91b4i5PL8DtyNKdwmcsGrV4fg+erwWOmD05CLIw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vue/devtools-shared": "^7.7.10",
+        "birpc": "^2.3.0",
+        "hookable": "^5.5.3",
+        "mitt": "^3.0.1",
+        "perfect-debounce": "^1.0.0",
+        "speakingurl": "^14.0.1",
+        "superjson": "^2.2.2"
+      }
+    },
+    "node_modules/@vue/devtools-shared": {
+      "version": "7.7.10",
+      "resolved": "https://registry.npmjs.org/@vue/devtools-shared/-/devtools-shared-7.7.10.tgz",
+      "integrity": "sha512-wOPslzB8vTvpxwdaOcR2qAbwmuSP0L+rhpoC6Cf56V3Jip+HWb7PQQXOUPgBNQARpXsbQX/+mvi8kKucmBGRwQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "rfdc": "^1.4.1"
+      }
+    },
+    "node_modules/@vue/reactivity": {
+      "version": "3.5.40",
+      "resolved": "https://registry.npmjs.org/@vue/reactivity/-/reactivity-3.5.40.tgz",
+      "integrity": "sha512-B7ot9UlUZOi1zbq61/LvE88ZLTV8IlajTdiZTAEiDQgrnIMIZoPr9kGw0Zw46ObW62O9+H/Be3kMbfb7kYPQZA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vue/shared": "3.5.40"
+      }
+    },
+    "node_modules/@vue/runtime-core": {
+      "version": "3.5.40",
+      "resolved": "https://registry.npmjs.org/@vue/runtime-core/-/runtime-core-3.5.40.tgz",
+      "integrity": "sha512-KAZLweuZ6uUJPK1PMSQPgBU5gCjgrrfjUhSglmU9NhH+Zjepa8cnwSydPWDWHDwOgY4g3VcZ+PljbiHlURNCbw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vue/reactivity": "3.5.40",
+        "@vue/shared": "3.5.40"
+      }
+    },
+    "node_modules/@vue/runtime-dom": {
+      "version": "3.5.40",
+      "resolved": "https://registry.npmjs.org/@vue/runtime-dom/-/runtime-dom-3.5.40.tgz",
+      "integrity": "sha512-ZfrX8ssZQds900L9pr8AuK05ddnMsR4MPMZr8cPN9GoqoPWcXLhjvvbIA2SMv+7a97sJ1vv9pj/zxK0Cq/eEFQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vue/reactivity": "3.5.40",
+        "@vue/runtime-core": "3.5.40",
+        "@vue/shared": "3.5.40",
+        "csstype": "^3.2.3"
+      }
+    },
+    "node_modules/@vue/server-renderer": {
+      "version": "3.5.40",
+      "resolved": "https://registry.npmjs.org/@vue/server-renderer/-/server-renderer-3.5.40.tgz",
+      "integrity": "sha512-XNJym9WpevhTVt1HuwOrCRJ5Q+9z4BjTMrDtjTrvx74SmUll8spNTw6whWJa9mEkO4PKn5TihI/bm/8ds2QVJw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vue/compiler-ssr": "3.5.40",
+        "@vue/runtime-dom": "3.5.40",
+        "@vue/shared": "3.5.40"
+      }
+    },
+    "node_modules/@vue/shared": {
+      "version": "3.5.40",
+      "resolved": "https://registry.npmjs.org/@vue/shared/-/shared-3.5.40.tgz",
+      "integrity": "sha512-WxnBtruIqOoV3rA4jeKDWzrYI5h7Cp4+pjwDi8kWGHz+IslhiN+wguLVVhtv2l8VoU02rzDCVfDjgCl1lNpZVg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@vueuse/core": {
+      "version": "12.8.2",
+      "resolved": "https://registry.npmjs.org/@vueuse/core/-/core-12.8.2.tgz",
+      "integrity": "sha512-HbvCmZdzAu3VGi/pWYm5Ut+Kd9mn1ZHnn4L5G8kOQTPs/IwIAmJoBrmYk2ckLArgMXZj0AW3n5CAejLUO+PhdQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/web-bluetooth": "^0.0.21",
+        "@vueuse/metadata": "12.8.2",
+        "@vueuse/shared": "12.8.2",
+        "vue": "^3.5.13"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/antfu"
+      }
+    },
+    "node_modules/@vueuse/integrations": {
+      "version": "12.8.2",
+      "resolved": "https://registry.npmjs.org/@vueuse/integrations/-/integrations-12.8.2.tgz",
+      "integrity": "sha512-fbGYivgK5uBTRt7p5F3zy6VrETlV9RtZjBqd1/HxGdjdckBgBM4ugP8LHpjolqTj14TXTxSK1ZfgPbHYyGuH7g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vueuse/core": "12.8.2",
+        "@vueuse/shared": "12.8.2",
+        "vue": "^3.5.13"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/antfu"
+      },
+      "peerDependencies": {
+        "async-validator": "^4",
+        "axios": "^1",
+        "change-case": "^5",
+        "drauu": "^0.4",
+        "focus-trap": "^7",
+        "fuse.js": "^7",
+        "idb-keyval": "^6",
+        "jwt-decode": "^4",
+        "nprogress": "^0.2",
+        "qrcode": "^1.5",
+        "sortablejs": "^1",
+        "universal-cookie": "^7"
+      },
+      "peerDependenciesMeta": {
+        "async-validator": {
+          "optional": true
+        },
+        "axios": {
+          "optional": true
+        },
+        "change-case": {
+          "optional": true
+        },
+        "drauu": {
+          "optional": true
+        },
+        "focus-trap": {
+          "optional": true
+        },
+        "fuse.js": {
+          "optional": true
+        },
+        "idb-keyval": {
+          "optional": true
+        },
+        "jwt-decode": {
+          "optional": true
+        },
+        "nprogress": {
+          "optional": true
+        },
+        "qrcode": {
+          "optional": true
+        },
+        "sortablejs": {
+          "optional": true
+        },
+        "universal-cookie": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@vueuse/metadata": {
+      "version": "12.8.2",
+      "resolved": "https://registry.npmjs.org/@vueuse/metadata/-/metadata-12.8.2.tgz",
+      "integrity": "sha512-rAyLGEuoBJ/Il5AmFHiziCPdQzRt88VxR+Y/A/QhJ1EWtWqPBBAxTAFaSkviwEuOEZNtW8pvkPgoCZQ+HxqW1A==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/antfu"
+      }
+    },
+    "node_modules/@vueuse/shared": {
+      "version": "12.8.2",
+      "resolved": "https://registry.npmjs.org/@vueuse/shared/-/shared-12.8.2.tgz",
+      "integrity": "sha512-dznP38YzxZoNloI0qpEfpkms8knDtaoQ6Y/sfS0L7Yki4zh40LFHEhur0odJC6xTHG5dxWVPiUWBXn+wCG2s5w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "vue": "^3.5.13"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/antfu"
+      }
+    },
     "node_modules/add-stream": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/add-stream/-/add-stream-1.0.0.tgz",
       "integrity": "sha512-qQLMr+8o0WC4FZGQTcJiKBVC59JylcPSrTtk6usvmIDFUOCKegapy1VHQwRbFMOFyb/inzUVqHs+eMYKDM1YeQ==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/algoliasearch": {
+      "version": "5.56.0",
+      "resolved": "https://registry.npmjs.org/algoliasearch/-/algoliasearch-5.56.0.tgz",
+      "integrity": "sha512-PrqppUmhT4ENdas2pH9caE7efUcxy6EcSFhWzosiVuQBzu2tQ5yLTI6jwomT/1cuBnivzGfxiJCqDNN9FRRh+Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@algolia/abtesting": "1.22.0",
+        "@algolia/client-abtesting": "5.56.0",
+        "@algolia/client-analytics": "5.56.0",
+        "@algolia/client-common": "5.56.0",
+        "@algolia/client-insights": "5.56.0",
+        "@algolia/client-personalization": "5.56.0",
+        "@algolia/client-query-suggestions": "5.56.0",
+        "@algolia/client-search": "5.56.0",
+        "@algolia/ingestion": "1.56.0",
+        "@algolia/monitoring": "1.56.0",
+        "@algolia/recommend": "5.56.0",
+        "@algolia/requester-browser-xhr": "5.56.0",
+        "@algolia/requester-fetch": "5.56.0",
+        "@algolia/requester-node-http": "5.56.0"
+      },
+      "engines": {
+        "node": ">= 14.0.0"
+      }
     },
     "node_modules/array-ify": {
       "version": "1.0.0",
@@ -1961,6 +2769,27 @@
         "require-from-string": "^2.0.2"
       }
     },
+    "node_modules/birpc": {
+      "version": "2.9.0",
+      "resolved": "https://registry.npmjs.org/birpc/-/birpc-2.9.0.tgz",
+      "integrity": "sha512-KrayHS5pBi69Xi9JmvoqrIgYGDkD6mcSe/i6YKi3w5kekCLzrX4+nawcXqrj2tIp50Kw/mT/s3p+GVK0A0sKxw==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/antfu"
+      }
+    },
+    "node_modules/ccount": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/ccount/-/ccount-2.0.1.tgz",
+      "integrity": "sha512-eyrF0jiFpY+3drT6383f1qhkbGsLSifNAjA61IUjZjmLCWjItY6LB9ft9YhoDgwfmclB2zhu51Lc7+95b8NRAg==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
+    },
     "node_modules/chai": {
       "version": "6.2.2",
       "resolved": "https://registry.npmjs.org/chai/-/chai-6.2.2.tgz",
@@ -1969,6 +2798,39 @@
       "license": "MIT",
       "engines": {
         "node": ">=18"
+      }
+    },
+    "node_modules/character-entities-html4": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/character-entities-html4/-/character-entities-html4-2.1.0.tgz",
+      "integrity": "sha512-1v7fgQRj6hnSwFpq1Eu0ynr/CDEw0rXo2B61qXrLNdHZmPKgb7fqS1a2JwF0rISo9q77jDI8VMEHoApn8qDoZA==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
+    },
+    "node_modules/character-entities-legacy": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/character-entities-legacy/-/character-entities-legacy-3.0.0.tgz",
+      "integrity": "sha512-RpPp0asT/6ufRm//AJVwpViZbGM/MkjQFxJccQRHmISF/22NBtsHqAWmL+/pmkPWoIUJdWyeVleTl1wydHATVQ==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
+    },
+    "node_modules/comma-separated-tokens": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/comma-separated-tokens/-/comma-separated-tokens-2.0.3.tgz",
+      "integrity": "sha512-Fu4hJdvzeylCfQPp9SGWidpzrMs7tTrlu6Vb8XGaRGck8QSNZJJp538Wrb60Lax4fPwR64ViY468OIUTbRlGZg==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
       }
     },
     "node_modules/commondir": {
@@ -2237,6 +3099,22 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/copy-anything": {
+      "version": "4.0.5",
+      "resolved": "https://registry.npmjs.org/copy-anything/-/copy-anything-4.0.5.tgz",
+      "integrity": "sha512-7Vv6asjS4gMOuILabD3l739tsaxFQmC+a7pLZm02zyvs8p977bL3zEgq3yDk5rn9B0PbYgIv++jmHcuUab4RhA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "is-what": "^5.2.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/mesqueeb"
+      }
+    },
     "node_modules/cross-spawn": {
       "version": "7.0.6",
       "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.6.tgz",
@@ -2265,6 +3143,13 @@
       "engines": {
         "node": "^10 || ^12.20.0 || ^14.13.0 || >=15.0.0"
       }
+    },
+    "node_modules/csstype": {
+      "version": "3.2.3",
+      "resolved": "https://registry.npmjs.org/csstype/-/csstype-3.2.3.tgz",
+      "integrity": "sha512-z1HGKcYy2xA8AGQfwrn0PAy+PB7X/GSj3UVJW9qKyn43xWa+gl5nXmU4qqLMRzWVLFC8KusUX8T/0kCiOYpAIQ==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/data-urls": {
       "version": "7.0.0",
@@ -2315,6 +3200,16 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/dequal": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/dequal/-/dequal-2.0.3.tgz",
+      "integrity": "sha512-0je+qPKHEMohvfRTCEo3CrPG6cAzAYgmzKyxRiYSSDkS6eGJdyVJm7WaYA5ECaAD9wLB2T4EEeymA5aFVcYXCA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
     "node_modules/detect-libc": {
       "version": "2.1.2",
       "resolved": "https://registry.npmjs.org/detect-libc/-/detect-libc-2.1.2.tgz",
@@ -2323,6 +3218,20 @@
       "license": "Apache-2.0",
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/devlop": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/devlop/-/devlop-1.1.0.tgz",
+      "integrity": "sha512-RWmIqhcFf1lRYBvNmr7qTNuyCt/7/ns2jbpp1+PalgE/rDQcBT0fioSMUpJ93irlUhC5hrg4cYqe6U+0ImW0rA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "dequal": "^2.0.0"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
       }
     },
     "node_modules/dompurify": {
@@ -2346,6 +3255,13 @@
       "engines": {
         "node": ">=8"
       }
+    },
+    "node_modules/emoji-regex-xs": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/emoji-regex-xs/-/emoji-regex-xs-1.0.0.tgz",
+      "integrity": "sha512-LRlerrMYoIDrT6jgpeZ2YYl/L8EulRTt5hQcYjy5AInh7HWXKimpqx68aknBFpGL2+/IcogTcaydJEgaTmOpDg==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/entities": {
       "version": "8.0.0",
@@ -2541,6 +3457,16 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/focus-trap": {
+      "version": "7.8.0",
+      "resolved": "https://registry.npmjs.org/focus-trap/-/focus-trap-7.8.0.tgz",
+      "integrity": "sha512-/yNdlIkpWbM0ptxno3ONTuf+2g318kh2ez3KSeZN5dZ8YC6AAmgeWz+GasYYiBJPFaYcSAPeu4GfhUaChzIJXA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "tabbable": "^6.4.0"
       }
     },
     "node_modules/fs-extra": {
@@ -2797,12 +3723,57 @@
         "node": ">= 0.4"
       }
     },
+    "node_modules/hast-util-to-html": {
+      "version": "9.0.5",
+      "resolved": "https://registry.npmjs.org/hast-util-to-html/-/hast-util-to-html-9.0.5.tgz",
+      "integrity": "sha512-OguPdidb+fbHQSU4Q4ZiLKnzWo8Wwsf5bZfbvu7//a9oTYoqD/fWpe96NuHkoS9h0ccGOTe0C4NGXdtS0iObOw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/hast": "^3.0.0",
+        "@types/unist": "^3.0.0",
+        "ccount": "^2.0.0",
+        "comma-separated-tokens": "^2.0.0",
+        "hast-util-whitespace": "^3.0.0",
+        "html-void-elements": "^3.0.0",
+        "mdast-util-to-hast": "^13.0.0",
+        "property-information": "^7.0.0",
+        "space-separated-tokens": "^2.0.0",
+        "stringify-entities": "^4.0.0",
+        "zwitch": "^2.0.4"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/hast-util-whitespace": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/hast-util-whitespace/-/hast-util-whitespace-3.0.0.tgz",
+      "integrity": "sha512-88JUN06ipLwsnv+dVn+OIYOvAuvBMy/Qoi6O7mQHxdPXpjy+Cd6xRkWwux7DKO+4sYILtLBRIKgsdpS2gQc7qw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/hast": "^3.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
     "node_modules/home-assistant-js-websocket": {
       "version": "9.6.0",
       "resolved": "https://registry.npmjs.org/home-assistant-js-websocket/-/home-assistant-js-websocket-9.6.0.tgz",
       "integrity": "sha512-TK8HWW6UjCsUdjIBQRB2sBbEya0VniOBFqFjgqSznJiB7YriNgN8jghyThxOkgxwrnt2eN6oWoZMCTSp1o7H+w==",
       "dev": true,
       "license": "Apache-2.0"
+    },
+    "node_modules/hookable": {
+      "version": "5.5.3",
+      "resolved": "https://registry.npmjs.org/hookable/-/hookable-5.5.3.tgz",
+      "integrity": "sha512-Yc+BQe8SvoXH1643Qez1zqLRmbA5rCL+sSmk6TVos0LWVfNIB7PGncdlId77WzLGSIB5KaWgTaNTs2lNVEI6VQ==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/hosted-git-info": {
       "version": "7.0.2",
@@ -2828,6 +3799,17 @@
       },
       "engines": {
         "node": "^20.19.0 || ^22.12.0 || >=24.0.0"
+      }
+    },
+    "node_modules/html-void-elements": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/html-void-elements/-/html-void-elements-3.0.0.tgz",
+      "integrity": "sha512-bEqo66MRXsUGxWHV5IP0PUiAWwoEjba4VCzg0LjFJBpchPaTfyfCKTG6bc5F8ucKec3q5y6qOdGyYTSBEvhCrg==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
       }
     },
     "node_modules/human-signals": {
@@ -2940,6 +3922,19 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/is-what": {
+      "version": "5.5.0",
+      "resolved": "https://registry.npmjs.org/is-what/-/is-what-5.5.0.tgz",
+      "integrity": "sha512-oG7cgbmg5kLYae2N5IVd3jm2s+vldjxJzK1pcu9LfpGuQ93MQSzo0okvRna+7y5ifrD+20FE8FvjusyGaz14fw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/mesqueeb"
       }
     },
     "node_modules/isexe": {
@@ -3380,6 +4375,35 @@
         "semver": "bin/semver.js"
       }
     },
+    "node_modules/mark.js": {
+      "version": "8.11.1",
+      "resolved": "https://registry.npmjs.org/mark.js/-/mark.js-8.11.1.tgz",
+      "integrity": "sha512-1I+1qpDt4idfgLQG+BNWmrqku+7/2bi5nLf4YwF8y8zXvmfiTBY3PV3ZibfrjBueCByROpuBjLLFCajqkgYoLQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/mdast-util-to-hast": {
+      "version": "13.2.1",
+      "resolved": "https://registry.npmjs.org/mdast-util-to-hast/-/mdast-util-to-hast-13.2.1.tgz",
+      "integrity": "sha512-cctsq2wp5vTsLIcaymblUriiTcZd0CwWtCbLvrOzYCDZoWyMNV8sZ7krj09FSnsiJi3WVsHLM4k6Dq/yaPyCXA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/hast": "^3.0.0",
+        "@types/mdast": "^4.0.0",
+        "@ungap/structured-clone": "^1.0.0",
+        "devlop": "^1.0.0",
+        "micromark-util-sanitize-uri": "^2.0.0",
+        "trim-lines": "^3.0.0",
+        "unist-util-position": "^5.0.0",
+        "unist-util-visit": "^5.0.0",
+        "vfile": "^6.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
     "node_modules/mdn-data": {
       "version": "2.27.1",
       "resolved": "https://registry.npmjs.org/mdn-data/-/mdn-data-2.27.1.tgz",
@@ -3400,6 +4424,100 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/micromark-util-character": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/micromark-util-character/-/micromark-util-character-2.1.1.tgz",
+      "integrity": "sha512-wv8tdUTJ3thSFFFJKtpYKOYiGP2+v96Hvk4Tu8KpCAsTMs6yi+nVmGh1syvSCsaxz45J6Jbw+9DD6g97+NV67Q==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "micromark-util-symbol": "^2.0.0",
+        "micromark-util-types": "^2.0.0"
+      }
+    },
+    "node_modules/micromark-util-encode": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/micromark-util-encode/-/micromark-util-encode-2.0.1.tgz",
+      "integrity": "sha512-c3cVx2y4KqUnwopcO9b/SCdo2O67LwJJ/UyqGfbigahfegL9myoEFoDYZgkT7f36T0bLrM9hZTAaAyH+PCAXjw==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "license": "MIT"
+    },
+    "node_modules/micromark-util-sanitize-uri": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/micromark-util-sanitize-uri/-/micromark-util-sanitize-uri-2.0.1.tgz",
+      "integrity": "sha512-9N9IomZ/YuGGZZmQec1MbgxtlgougxTodVwDzzEouPKo3qFWvymFHWcnDi2vzV1ff6kas9ucW+o3yzJK9YB1AQ==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "micromark-util-character": "^2.0.0",
+        "micromark-util-encode": "^2.0.0",
+        "micromark-util-symbol": "^2.0.0"
+      }
+    },
+    "node_modules/micromark-util-symbol": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/micromark-util-symbol/-/micromark-util-symbol-2.0.1.tgz",
+      "integrity": "sha512-vs5t8Apaud9N28kgCrRUdEed4UJ+wWNvicHLPxCa9ENlYuAY31M0ETy5y1vA33YoNPDFTghEbnh6efaE8h4x0Q==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "license": "MIT"
+    },
+    "node_modules/micromark-util-types": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/micromark-util-types/-/micromark-util-types-2.0.2.tgz",
+      "integrity": "sha512-Yw0ECSpJoViF1qTU4DC6NwtC4aWGt1EkzaQB8KPPyCRR8z9TWeV0HbEFGTO+ZY1wB22zmxnJqhPyTpOVCpeHTA==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "license": "MIT"
+    },
     "node_modules/minimist": {
       "version": "1.2.8",
       "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.8.tgz",
@@ -3409,6 +4527,20 @@
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
       }
+    },
+    "node_modules/minisearch": {
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/minisearch/-/minisearch-7.2.0.tgz",
+      "integrity": "sha512-dqT2XBYUOZOiC5t2HRnwADjhNS2cecp9u+TJRiJ1Qp/f5qjkeT5APcGPjHw+bz89Ms8Jp+cG4AlE+QZ/QnDglg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/mitt": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/mitt/-/mitt-3.0.1.tgz",
+      "integrity": "sha512-vKivATfr97l2/QBCYAkXYDbrIWPM2IIKEl7YPhjCvKlG3kE2gm+uBo6nEXK3M5/Ffh/FLpKExzOQ3JJoJGFKBw==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/mrmime": {
       "version": "2.0.1",
@@ -3428,9 +4560,9 @@
       "license": "MIT"
     },
     "node_modules/nanoid": {
-      "version": "3.3.12",
-      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.12.tgz",
-      "integrity": "sha512-ZB9RH/39qpq5Vu6Y+NmUaFhQR6pp+M2Xt76XBnEwDaGcVAqhlvxrl3B2bKS5D3NH3QR76v3aSrKaF/Kiy7lEtQ==",
+      "version": "3.3.16",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.16.tgz",
+      "integrity": "sha512-bzlKTyNJ7+LdGIIwy8ijFpIqEQIvafahV7eYykJ8Cvh42EdJeODoJ6gUJXpQJvej1BddH8OqTXZNE/KfbWAu8Q==",
       "dev": true,
       "funding": [
         {
@@ -3508,6 +4640,18 @@
         "https://opencollective.com/debug"
       ],
       "license": "MIT"
+    },
+    "node_modules/oniguruma-to-es": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/oniguruma-to-es/-/oniguruma-to-es-3.1.1.tgz",
+      "integrity": "sha512-bUH8SDvPkH3ho3dvwJwfonjlQ4R80vjyvrU8YpxuROddv55vAEJrTuCuCVUhhsHbtlD9tGGbaNApGQckXhS8iQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "emoji-regex-xs": "^1.0.0",
+        "regex": "^6.0.1",
+        "regex-recursion": "^6.0.2"
+      }
     },
     "node_modules/p-limit": {
       "version": "2.3.0",
@@ -3626,6 +4770,13 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/perfect-debounce": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/perfect-debounce/-/perfect-debounce-1.0.0.tgz",
+      "integrity": "sha512-xCy9V055GLEqoFaHoC1SoLIaLmWctgCUaBaWxDZ7/Zx4CTyX7cJQLJOok/orfjZAh9kEYpjJa4d0KcJmCbctZA==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/picocolors": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/picocolors/-/picocolors-1.1.1.tgz",
@@ -3702,9 +4853,9 @@
       }
     },
     "node_modules/postcss": {
-      "version": "8.5.14",
-      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.14.tgz",
-      "integrity": "sha512-SoSL4+OSEtR99LHFZQiJLkT59C5B1amGO1NzTwj7TT1qCUgUO6hxOvzkOYxD+vMrXBM3XJIKzokoERdqQq/Zmg==",
+      "version": "8.5.25",
+      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.25.tgz",
+      "integrity": "sha512-DTPx3RWSSnWyzLxQnlH0rJP+EW5ekl16ZU4/psbIhA0e53kJfdgaN5vKM+xP7yJtXVu+nfdVFmlgFDEKAe4Pyw==",
       "dev": true,
       "funding": [
         {
@@ -3722,12 +4873,31 @@
       ],
       "license": "MIT",
       "dependencies": {
-        "nanoid": "^3.3.11",
+        "nanoid": "^3.3.16",
         "picocolors": "^1.1.1",
         "source-map-js": "^1.2.1"
       },
       "engines": {
         "node": "^10 || ^12 || >=14"
+      }
+    },
+    "node_modules/preact": {
+      "version": "10.29.8",
+      "resolved": "https://registry.npmjs.org/preact/-/preact-10.29.8.tgz",
+      "integrity": "sha512-ej2aVZ+vZ8WO7tvlQWRM9N63A0KzF9q4mWJfDUHgYaIofWY9hu74QdnQrjoPMmZi2/nZ5gN0bJCQF49xQqx09Q==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/preact"
+      },
+      "peerDependencies": {
+        "preact-render-to-string": ">=5"
+      },
+      "peerDependenciesMeta": {
+        "preact-render-to-string": {
+          "optional": true
+        }
       }
     },
     "node_modules/pretty-ms": {
@@ -3744,6 +4914,17 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/property-information": {
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/property-information/-/property-information-7.2.0.tgz",
+      "integrity": "sha512-IAtzIB6sUiWaJYrX9smp3V46pBGbBeLFRGdh25kg1334VcBlD8HzhPeNIWQH9zhGmo2itIe25EHt9dQP7G5hmg==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
       }
     },
     "node_modules/punycode": {
@@ -3807,6 +4988,33 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/regex": {
+      "version": "6.1.0",
+      "resolved": "https://registry.npmjs.org/regex/-/regex-6.1.0.tgz",
+      "integrity": "sha512-6VwtthbV4o/7+OaAF9I5L5V3llLEsoPyq9P1JVXkedTP33c7MfCG0/5NOPcSJn0TzXcG9YUrR0gQSWioew3LDg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "regex-utilities": "^2.3.0"
+      }
+    },
+    "node_modules/regex-recursion": {
+      "version": "6.0.2",
+      "resolved": "https://registry.npmjs.org/regex-recursion/-/regex-recursion-6.0.2.tgz",
+      "integrity": "sha512-0YCaSCq2VRIebiaUviZNs0cBz1kg5kVS2UKUfNIx8YVs1cN3AV7NTctO5FOKBA+UT2BPJIWZauYHPqJODG50cg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "regex-utilities": "^2.3.0"
+      }
+    },
+    "node_modules/regex-utilities": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/regex-utilities/-/regex-utilities-2.3.0.tgz",
+      "integrity": "sha512-8VhliFJAWRaUiVvREIiW2NXXTmHs4vMNnSzuJVhscgmGav3g9VDxLrQndI3dZZVVdp0ZO/5v0xmX516/7M9cng==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/require-from-string": {
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/require-from-string/-/require-from-string-2.0.2.tgz",
@@ -3848,6 +5056,13 @@
       "funding": {
         "url": "https://github.com/privatenumber/resolve-pkg-maps?sponsor=1"
       }
+    },
+    "node_modules/rfdc": {
+      "version": "1.4.1",
+      "resolved": "https://registry.npmjs.org/rfdc/-/rfdc-1.4.1.tgz",
+      "integrity": "sha512-q1b3N5QkRUWUl7iyylaaj3kOpIT0N2i9MqIEQXP73GVsN9cw3fdx8X63cEmWhJGi2PPCF23Ijp7ktmd39rawIA==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/rolldown": {
       "version": "1.0.0",
@@ -4020,6 +5235,14 @@
         "node": ">=v12.22.7"
       }
     },
+    "node_modules/search-insights": {
+      "version": "2.17.3",
+      "resolved": "https://registry.npmjs.org/search-insights/-/search-insights-2.17.3.tgz",
+      "integrity": "sha512-RQPdCYTa8A68uM2jwxoY842xDhvx3E5LFL1LxvxCNMev4o5mLuokczhzjAgGwUZBAmOKZknArSxLKmXtIi2AxQ==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true
+    },
     "node_modules/semver": {
       "version": "7.8.0",
       "resolved": "https://registry.npmjs.org/semver/-/semver-7.8.0.tgz",
@@ -4054,6 +5277,23 @@
       "license": "MIT",
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/shiki": {
+      "version": "2.5.0",
+      "resolved": "https://registry.npmjs.org/shiki/-/shiki-2.5.0.tgz",
+      "integrity": "sha512-mI//trrsaiCIPsja5CNfsyNOqgAZUb6VpJA+340toL42UpzQlXpwRV9nch69X6gaUxrr9kaOOa6e3y3uAkGFxQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@shikijs/core": "2.5.0",
+        "@shikijs/engine-javascript": "2.5.0",
+        "@shikijs/engine-oniguruma": "2.5.0",
+        "@shikijs/langs": "2.5.0",
+        "@shikijs/themes": "2.5.0",
+        "@shikijs/types": "2.5.0",
+        "@shikijs/vscode-textmate": "^10.0.2",
+        "@types/hast": "^3.0.4"
       }
     },
     "node_modules/siginfo": {
@@ -4111,6 +5351,17 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/space-separated-tokens": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/space-separated-tokens/-/space-separated-tokens-2.0.2.tgz",
+      "integrity": "sha512-PEGlAwrG8yXGXRjW32fGbg66JAlOAwbObuqVoJpv/mRgoWDQfgH1wDPvtzWyUSNAXBGSk8h755YDbbcEy3SH2Q==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
+    },
     "node_modules/spdx-correct": {
       "version": "3.2.0",
       "resolved": "https://registry.npmjs.org/spdx-correct/-/spdx-correct-3.2.0.tgz",
@@ -4147,6 +5398,16 @@
       "dev": true,
       "license": "CC0-1.0"
     },
+    "node_modules/speakingurl": {
+      "version": "14.0.1",
+      "resolved": "https://registry.npmjs.org/speakingurl/-/speakingurl-14.0.1.tgz",
+      "integrity": "sha512-1POYv7uv2gXoyGFpBCmpDVSNV74IfsWlDW216UPjbWufNf+bSU6GdbDsxdcxtfwb4xlI3yxzOTKClUosxARYrQ==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
     "node_modules/stackback": {
       "version": "0.0.2",
       "resolved": "https://registry.npmjs.org/stackback/-/stackback-0.0.2.tgz",
@@ -4161,6 +5422,21 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/stringify-entities": {
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/stringify-entities/-/stringify-entities-4.0.4.tgz",
+      "integrity": "sha512-IwfBptatlO+QCJUo19AqvrPNqlVMpW9YEL2LIVY+Rpv2qsjCGxaDLNRgeGsQWJhfItebuJhsGSLjaBbNSQ+ieg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "character-entities-html4": "^2.0.0",
+        "character-entities-legacy": "^3.0.0"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
+    },
     "node_modules/strip-final-newline": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/strip-final-newline/-/strip-final-newline-4.0.0.tgz",
@@ -4172,6 +5448,19 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/superjson": {
+      "version": "2.2.6",
+      "resolved": "https://registry.npmjs.org/superjson/-/superjson-2.2.6.tgz",
+      "integrity": "sha512-H+ue8Zo4vJmV2nRjpx86P35lzwDT3nItnIsocgumgr0hHMQ+ZGq5vrERg9kJBo5AWGmxZDhzDo+WVIJqkB0cGA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "copy-anything": "^4"
+      },
+      "engines": {
+        "node": ">=16"
       }
     },
     "node_modules/supports-preserve-symlinks-flag": {
@@ -4191,6 +5480,13 @@
       "version": "3.2.4",
       "resolved": "https://registry.npmjs.org/symbol-tree/-/symbol-tree-3.2.4.tgz",
       "integrity": "sha512-9QNk5KwDF+Bvz+PyObkmSYjI5ksVUYtjW7AU22r2NKcfLJcXp96hkDWU3+XndOsUb+AQ9QhfzfCT2O+CNWT5Tw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/tabbable": {
+      "version": "6.5.0",
+      "resolved": "https://registry.npmjs.org/tabbable/-/tabbable-6.5.0.tgz",
+      "integrity": "sha512-wieBHXygIm7OyQOu5hQlkk62/WyCFYGlWg7L6/ZCUZwx0o398Zkn4pVmMyfYhfMG8kGrj/Krt8eIk6UKC6VzwA==",
       "dev": true,
       "license": "MIT"
     },
@@ -4320,6 +5616,17 @@
         "node": ">=20"
       }
     },
+    "node_modules/trim-lines": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/trim-lines/-/trim-lines-3.0.1.tgz",
+      "integrity": "sha512-kRj8B+YHZCc9kQYdWfJB2/oUl9rA99qbowYYBtr4ui4mZyAQ2JpvVBd/6U2YloATfqBhBTSMhTpgBHtU0Mf3Rg==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
+    },
     "node_modules/tslib": {
       "version": "2.8.1",
       "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
@@ -4391,6 +5698,79 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/unist-util-is": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/unist-util-is/-/unist-util-is-6.0.1.tgz",
+      "integrity": "sha512-LsiILbtBETkDz8I9p1dQ0uyRUWuaQzd/cuEeS1hoRSyW5E5XGmTzlwY1OrNzzakGowI9Dr/I8HVaw4hTtnxy8g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/unist": "^3.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/unist-util-position": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/unist-util-position/-/unist-util-position-5.0.0.tgz",
+      "integrity": "sha512-fucsC7HjXvkB5R3kTCO7kUjRdrS0BJt3M/FPxmHMBOm8JQi2BsHAHFsy27E0EolP8rp0NzXsJ+jNPyDWvOJZPA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/unist": "^3.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/unist-util-stringify-position": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/unist-util-stringify-position/-/unist-util-stringify-position-4.0.0.tgz",
+      "integrity": "sha512-0ASV06AAoKCDkS2+xw5RXJywruurpbC4JZSm7nr7MOt1ojAzvyyaO+UxZf18j8FCF6kmzCZKcAgN/yu2gm2XgQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/unist": "^3.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/unist-util-visit": {
+      "version": "5.1.0",
+      "resolved": "https://registry.npmjs.org/unist-util-visit/-/unist-util-visit-5.1.0.tgz",
+      "integrity": "sha512-m+vIdyeCOpdr/QeQCu2EzxX/ohgS8KbnPDgFni4dQsfSCtpz8UqDyY5GjRru8PDKuYn7Fq19j1CQ+nJSsGKOzg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/unist": "^3.0.0",
+        "unist-util-is": "^6.0.0",
+        "unist-util-visit-parents": "^6.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/unist-util-visit-parents": {
+      "version": "6.0.2",
+      "resolved": "https://registry.npmjs.org/unist-util-visit-parents/-/unist-util-visit-parents-6.0.2.tgz",
+      "integrity": "sha512-goh1s1TBrqSqukSc8wrjwWhL0hiJxgA8m4kFxGlQ+8FYQ3C/m11FcTs4YYem7V664AhHVvgoQLk890Ssdsr2IQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/unist": "^3.0.0",
+        "unist-util-is": "^6.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
     "node_modules/universalify": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/universalify/-/universalify-2.0.1.tgz",
@@ -4427,6 +5807,36 @@
       "dependencies": {
         "spdx-correct": "^3.0.0",
         "spdx-expression-parse": "^3.0.0"
+      }
+    },
+    "node_modules/vfile": {
+      "version": "6.0.3",
+      "resolved": "https://registry.npmjs.org/vfile/-/vfile-6.0.3.tgz",
+      "integrity": "sha512-KzIbH/9tXat2u30jf+smMwFCsno4wHVdNmzFyL+T/L3UGqqk6JKfVqOFOZEpZSHADH1k40ab6NUIXZq422ov3Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/unist": "^3.0.0",
+        "vfile-message": "^4.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/vfile-message": {
+      "version": "4.0.3",
+      "resolved": "https://registry.npmjs.org/vfile-message/-/vfile-message-4.0.3.tgz",
+      "integrity": "sha512-QTHzsGd1EhbZs4AsQ20JX1rC3cOlt/IWJruk893DfLRr57lcnOeMaWG4K0JrRta4mIJZKth2Au3mM3u03/JWKw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/unist": "^3.0.0",
+        "unist-util-stringify-position": "^4.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
       }
     },
     "node_modules/vite": {
@@ -4522,6 +5932,567 @@
         "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
       }
     },
+    "node_modules/vitepress": {
+      "version": "1.6.4",
+      "resolved": "https://registry.npmjs.org/vitepress/-/vitepress-1.6.4.tgz",
+      "integrity": "sha512-+2ym1/+0VVrbhNyRoFFesVvBvHAVMZMK0rw60E3X/5349M1GuVdKeazuksqopEdvkKwKGs21Q729jX81/bkBJg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@docsearch/css": "3.8.2",
+        "@docsearch/js": "3.8.2",
+        "@iconify-json/simple-icons": "^1.2.21",
+        "@shikijs/core": "^2.1.0",
+        "@shikijs/transformers": "^2.1.0",
+        "@shikijs/types": "^2.1.0",
+        "@types/markdown-it": "^14.1.2",
+        "@vitejs/plugin-vue": "^5.2.1",
+        "@vue/devtools-api": "^7.7.0",
+        "@vue/shared": "^3.5.13",
+        "@vueuse/core": "^12.4.0",
+        "@vueuse/integrations": "^12.4.0",
+        "focus-trap": "^7.6.4",
+        "mark.js": "8.11.1",
+        "minisearch": "^7.1.1",
+        "shiki": "^2.1.0",
+        "vite": "^5.4.14",
+        "vue": "^3.5.13"
+      },
+      "bin": {
+        "vitepress": "bin/vitepress.js"
+      },
+      "peerDependencies": {
+        "markdown-it-mathjax3": "^4",
+        "postcss": "^8"
+      },
+      "peerDependenciesMeta": {
+        "markdown-it-mathjax3": {
+          "optional": true
+        },
+        "postcss": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/vitepress/node_modules/@esbuild/aix-ppc64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/aix-ppc64/-/aix-ppc64-0.21.5.tgz",
+      "integrity": "sha512-1SDgH6ZSPTlggy1yI6+Dbkiz8xzpHJEVAlF/AM1tHPLsf5STom9rwtjE4hKAF20FfXXNTFqEYXyJNWh1GiZedQ==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "aix"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/vitepress/node_modules/@esbuild/android-arm": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm/-/android-arm-0.21.5.tgz",
+      "integrity": "sha512-vCPvzSjpPHEi1siZdlvAlsPxXl7WbOVUBBAowWug4rJHb68Ox8KualB+1ocNvT5fjv6wpkX6o/iEpbDrf68zcg==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/vitepress/node_modules/@esbuild/android-arm64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm64/-/android-arm64-0.21.5.tgz",
+      "integrity": "sha512-c0uX9VAUBQ7dTDCjq+wdyGLowMdtR/GoC2U5IYk/7D1H1JYC0qseD7+11iMP2mRLN9RcCMRcjC4YMclCzGwS/A==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/vitepress/node_modules/@esbuild/android-x64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-x64/-/android-x64-0.21.5.tgz",
+      "integrity": "sha512-D7aPRUUNHRBwHxzxRvp856rjUHRFW1SdQATKXH2hqA0kAZb1hKmi02OpYRacl0TxIGz/ZmXWlbZgjwWYaCakTA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/vitepress/node_modules/@esbuild/darwin-arm64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-arm64/-/darwin-arm64-0.21.5.tgz",
+      "integrity": "sha512-DwqXqZyuk5AiWWf3UfLiRDJ5EDd49zg6O9wclZ7kUMv2WRFr4HKjXp/5t8JZ11QbQfUS6/cRCKGwYhtNAY88kQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/vitepress/node_modules/@esbuild/darwin-x64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-x64/-/darwin-x64-0.21.5.tgz",
+      "integrity": "sha512-se/JjF8NlmKVG4kNIuyWMV/22ZaerB+qaSi5MdrXtd6R08kvs2qCN4C09miupktDitvh8jRFflwGFBQcxZRjbw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/vitepress/node_modules/@esbuild/freebsd-arm64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-arm64/-/freebsd-arm64-0.21.5.tgz",
+      "integrity": "sha512-5JcRxxRDUJLX8JXp/wcBCy3pENnCgBR9bN6JsY4OmhfUtIHe3ZW0mawA7+RDAcMLrMIZaf03NlQiX9DGyB8h4g==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/vitepress/node_modules/@esbuild/freebsd-x64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-x64/-/freebsd-x64-0.21.5.tgz",
+      "integrity": "sha512-J95kNBj1zkbMXtHVH29bBriQygMXqoVQOQYA+ISs0/2l3T9/kj42ow2mpqerRBxDJnmkUDCaQT/dfNXWX/ZZCQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/vitepress/node_modules/@esbuild/linux-arm": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm/-/linux-arm-0.21.5.tgz",
+      "integrity": "sha512-bPb5AHZtbeNGjCKVZ9UGqGwo8EUu4cLq68E95A53KlxAPRmUyYv2D6F0uUI65XisGOL1hBP5mTronbgo+0bFcA==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/vitepress/node_modules/@esbuild/linux-arm64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm64/-/linux-arm64-0.21.5.tgz",
+      "integrity": "sha512-ibKvmyYzKsBeX8d8I7MH/TMfWDXBF3db4qM6sy+7re0YXya+K1cem3on9XgdT2EQGMu4hQyZhan7TeQ8XkGp4Q==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/vitepress/node_modules/@esbuild/linux-ia32": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ia32/-/linux-ia32-0.21.5.tgz",
+      "integrity": "sha512-YvjXDqLRqPDl2dvRODYmmhz4rPeVKYvppfGYKSNGdyZkA01046pLWyRKKI3ax8fbJoK5QbxblURkwK/MWY18Tg==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/vitepress/node_modules/@esbuild/linux-loong64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.21.5.tgz",
+      "integrity": "sha512-uHf1BmMG8qEvzdrzAqg2SIG/02+4/DHB6a9Kbya0XDvwDEKCoC8ZRWI5JJvNdUjtciBGFQ5PuBlpEOXQj+JQSg==",
+      "cpu": [
+        "loong64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/vitepress/node_modules/@esbuild/linux-mips64el": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-mips64el/-/linux-mips64el-0.21.5.tgz",
+      "integrity": "sha512-IajOmO+KJK23bj52dFSNCMsz1QP1DqM6cwLUv3W1QwyxkyIWecfafnI555fvSGqEKwjMXVLokcV5ygHW5b3Jbg==",
+      "cpu": [
+        "mips64el"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/vitepress/node_modules/@esbuild/linux-ppc64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ppc64/-/linux-ppc64-0.21.5.tgz",
+      "integrity": "sha512-1hHV/Z4OEfMwpLO8rp7CvlhBDnjsC3CttJXIhBi+5Aj5r+MBvy4egg7wCbe//hSsT+RvDAG7s81tAvpL2XAE4w==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/vitepress/node_modules/@esbuild/linux-riscv64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-riscv64/-/linux-riscv64-0.21.5.tgz",
+      "integrity": "sha512-2HdXDMd9GMgTGrPWnJzP2ALSokE/0O5HhTUvWIbD3YdjME8JwvSCnNGBnTThKGEB91OZhzrJ4qIIxk/SBmyDDA==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/vitepress/node_modules/@esbuild/linux-s390x": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-s390x/-/linux-s390x-0.21.5.tgz",
+      "integrity": "sha512-zus5sxzqBJD3eXxwvjN1yQkRepANgxE9lgOW2qLnmr8ikMTphkjgXu1HR01K4FJg8h1kEEDAqDcZQtbrRnB41A==",
+      "cpu": [
+        "s390x"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/vitepress/node_modules/@esbuild/linux-x64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-x64/-/linux-x64-0.21.5.tgz",
+      "integrity": "sha512-1rYdTpyv03iycF1+BhzrzQJCdOuAOtaqHTWJZCWvijKD2N5Xu0TtVC8/+1faWqcP9iBCWOmjmhoH94dH82BxPQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/vitepress/node_modules/@esbuild/netbsd-x64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-x64/-/netbsd-x64-0.21.5.tgz",
+      "integrity": "sha512-Woi2MXzXjMULccIwMnLciyZH4nCIMpWQAs049KEeMvOcNADVxo0UBIQPfSmxB3CWKedngg7sWZdLvLczpe0tLg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "netbsd"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/vitepress/node_modules/@esbuild/openbsd-x64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-x64/-/openbsd-x64-0.21.5.tgz",
+      "integrity": "sha512-HLNNw99xsvx12lFBUwoT8EVCsSvRNDVxNpjZ7bPn947b8gJPzeHWyNVhFsaerc0n3TsbOINvRP2byTZ5LKezow==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/vitepress/node_modules/@esbuild/sunos-x64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/sunos-x64/-/sunos-x64-0.21.5.tgz",
+      "integrity": "sha512-6+gjmFpfy0BHU5Tpptkuh8+uw3mnrvgs+dSPQXQOv3ekbordwnzTVEb4qnIvQcYXq6gzkyTnoZ9dZG+D4garKg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "sunos"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/vitepress/node_modules/@esbuild/win32-arm64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-arm64/-/win32-arm64-0.21.5.tgz",
+      "integrity": "sha512-Z0gOTd75VvXqyq7nsl93zwahcTROgqvuAcYDUr+vOv8uHhNSKROyU961kgtCD1e95IqPKSQKH7tBTslnS3tA8A==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/vitepress/node_modules/@esbuild/win32-ia32": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-ia32/-/win32-ia32-0.21.5.tgz",
+      "integrity": "sha512-SWXFF1CL2RVNMaVs+BBClwtfZSvDgtL//G/smwAc5oVK/UPu2Gu9tIaRgFmYFFKrmg3SyAjSrElf0TiJ1v8fYA==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/vitepress/node_modules/@esbuild/win32-x64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-x64/-/win32-x64-0.21.5.tgz",
+      "integrity": "sha512-tQd/1efJuzPC6rCFwEvLtci/xNFcTZknmXs98FYDfGE4wP9ClFV98nyKrzJKVPMhdDnjzLhdUyMX4PsQAPjwIw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/vitepress/node_modules/@vitejs/plugin-vue": {
+      "version": "5.2.4",
+      "resolved": "https://registry.npmjs.org/@vitejs/plugin-vue/-/plugin-vue-5.2.4.tgz",
+      "integrity": "sha512-7Yx/SXSOcQq5HiiV3orevHUFn+pmMB4cgbEkDYgnkUWb0WfeQ/wa2yFv6D5ICiCQOVpjA7vYDXrC7AGO8yjDHA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^18.0.0 || >=20.0.0"
+      },
+      "peerDependencies": {
+        "vite": "^5.0.0 || ^6.0.0",
+        "vue": "^3.2.25"
+      }
+    },
+    "node_modules/vitepress/node_modules/esbuild": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.21.5.tgz",
+      "integrity": "sha512-mg3OPMV4hXywwpoDxu3Qda5xCKQi+vCTZq8S9J/EpkhB2HzKXq4SNFZE3+NK93JYxc8VMSep+lOUSC/RVKaBqw==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "bin": {
+        "esbuild": "bin/esbuild"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "optionalDependencies": {
+        "@esbuild/aix-ppc64": "0.21.5",
+        "@esbuild/android-arm": "0.21.5",
+        "@esbuild/android-arm64": "0.21.5",
+        "@esbuild/android-x64": "0.21.5",
+        "@esbuild/darwin-arm64": "0.21.5",
+        "@esbuild/darwin-x64": "0.21.5",
+        "@esbuild/freebsd-arm64": "0.21.5",
+        "@esbuild/freebsd-x64": "0.21.5",
+        "@esbuild/linux-arm": "0.21.5",
+        "@esbuild/linux-arm64": "0.21.5",
+        "@esbuild/linux-ia32": "0.21.5",
+        "@esbuild/linux-loong64": "0.21.5",
+        "@esbuild/linux-mips64el": "0.21.5",
+        "@esbuild/linux-ppc64": "0.21.5",
+        "@esbuild/linux-riscv64": "0.21.5",
+        "@esbuild/linux-s390x": "0.21.5",
+        "@esbuild/linux-x64": "0.21.5",
+        "@esbuild/netbsd-x64": "0.21.5",
+        "@esbuild/openbsd-x64": "0.21.5",
+        "@esbuild/sunos-x64": "0.21.5",
+        "@esbuild/win32-arm64": "0.21.5",
+        "@esbuild/win32-ia32": "0.21.5",
+        "@esbuild/win32-x64": "0.21.5"
+      }
+    },
+    "node_modules/vitepress/node_modules/fsevents": {
+      "version": "2.3.3",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.3.tgz",
+      "integrity": "sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
+      }
+    },
+    "node_modules/vitepress/node_modules/vite": {
+      "version": "5.4.21",
+      "resolved": "https://registry.npmjs.org/vite/-/vite-5.4.21.tgz",
+      "integrity": "sha512-o5a9xKjbtuhY6Bi5S3+HvbRERmouabWbyUcpXXUA1u+GNUKoROi9byOJ8M0nHbHYHkYICiMlqxkg1KkYmm25Sw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "esbuild": "^0.21.3",
+        "postcss": "^8.4.43",
+        "rollup": "^4.20.0"
+      },
+      "bin": {
+        "vite": "bin/vite.js"
+      },
+      "engines": {
+        "node": "^18.0.0 || >=20.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/vitejs/vite?sponsor=1"
+      },
+      "optionalDependencies": {
+        "fsevents": "~2.3.3"
+      },
+      "peerDependencies": {
+        "@types/node": "^18.0.0 || >=20.0.0",
+        "less": "*",
+        "lightningcss": "^1.21.0",
+        "sass": "*",
+        "sass-embedded": "*",
+        "stylus": "*",
+        "sugarss": "*",
+        "terser": "^5.4.0"
+      },
+      "peerDependenciesMeta": {
+        "@types/node": {
+          "optional": true
+        },
+        "less": {
+          "optional": true
+        },
+        "lightningcss": {
+          "optional": true
+        },
+        "sass": {
+          "optional": true
+        },
+        "sass-embedded": {
+          "optional": true
+        },
+        "stylus": {
+          "optional": true
+        },
+        "sugarss": {
+          "optional": true
+        },
+        "terser": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/vitest": {
       "version": "4.1.6",
       "resolved": "https://registry.npmjs.org/vitest/-/vitest-4.1.6.tgz",
@@ -4609,6 +6580,28 @@
         },
         "vite": {
           "optional": false
+        }
+      }
+    },
+    "node_modules/vue": {
+      "version": "3.5.40",
+      "resolved": "https://registry.npmjs.org/vue/-/vue-3.5.40.tgz",
+      "integrity": "sha512-+8PJ4SJXdn/cHGImF4CKdxlWHIN5Dkt7DoufRREM6h6uVCx2m7QxgcEQmmzyOK8A9mcafg7sFbJFYsdFVubTig==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vue/compiler-dom": "3.5.40",
+        "@vue/compiler-sfc": "3.5.40",
+        "@vue/runtime-dom": "3.5.40",
+        "@vue/server-renderer": "3.5.40",
+        "@vue/shared": "3.5.40"
+      },
+      "peerDependencies": {
+        "typescript": "*"
+      },
+      "peerDependenciesMeta": {
+        "typescript": {
+          "optional": true
         }
       }
     },
@@ -4750,6 +6743,17 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/zwitch": {
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/zwitch/-/zwitch-2.0.4.tgz",
+      "integrity": "sha512-bXE4cR/kVZhKZX/RjPEflHaKVhUVl85noU3v6b8apfQEc1x4A+zBxjZ4lN8LqGd6WZ3dl98pY4o717VFmoPp+A==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
       }
     }
   }

--- a/package.json
+++ b/package.json
@@ -12,7 +12,11 @@
     "test:watch": "vitest",
     "screenshot": "node scripts/screenshot.js",
     "screenshot:update": "npm run build && npm run screenshot",
-    "screenshot:hero": "npm run build && npm run screenshot && bash scripts/encode-adaptive-svgs.sh"
+    "screenshot:hero": "npm run build && npm run screenshot && bash scripts/encode-adaptive-svgs.sh",
+    "docs:dev": "vitepress dev docs",
+    "docs:build": "vitepress build docs",
+    "docs:preview": "vitepress preview docs",
+    "docs:media": "bash scripts/build-docs-media.sh"
   },
   "keywords": [
     "home-assistant",
@@ -43,6 +47,7 @@
     "rollup-plugin-typescript2": "^0.37.0",
     "semver": "^7.7.4",
     "typescript": "^6.0.3",
+    "vitepress": "^1.6.4",
     "vitest": "^4.0.18"
   },
   "dependencies": {

--- a/scripts/build-docs-media.sh
+++ b/scripts/build-docs-media.sh
@@ -1,0 +1,60 @@
+#!/usr/bin/env bash
+# Generates the docs-site figures and stages them under docs/public/img/.
+#
+# Docs figures are NOT committed. They are regenerated deterministically from
+# the harnesses on every Pages build (see .github/workflows/docs.yml) and both
+# img/ (beyond the six storefront files) and docs/public/img/ are gitignored.
+#
+# The scene content is deterministic (frozen clock, fixed fixtures), but the
+# encoded bytes are not portable: a different Chromium or ImageMagick build
+# re-encodes the same scene to a slightly different file. So this rewrites the
+# six *tracked* storefront figures in place and leaves them dirty, exactly as
+# `npm run screenshot:hero` already did. That is harmless in CI (nothing is
+# committed there); locally, `git restore img/` afterwards unless you actually
+# mean to refresh the storefront — which is a release-time job, not a docs one.
+#
+# Run: npm run docs:media
+#
+# Env: DOCS_MOTION=1  also record the tap_action motion capture (WebM + animated
+#                     WebP). Off by default: it needs ffmpeg *and* ffprobe, and
+#                     the motion demo is still being tuned.
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
+DEST="$ROOT/docs/public/img"
+
+cd "$ROOT"
+
+# The harnesses import /dist/weather-alerts-card.js, so the bundle must be current.
+npm run build
+
+node scripts/screenshot.js
+bash scripts/encode-adaptive-svgs.sh
+
+if [[ "${DOCS_MOTION:-}" == "1" ]]; then
+  node scripts/capture-tap-action.js
+fi
+
+mkdir -p "$DEST"
+
+# The site embeds the adaptive SVGs — one theme-aware URL each, with both
+# rasters already inlined as base64. The WebPs come along so a figure can be
+# opened on its own, and because DOCS_MOTION emits the animated capture as one.
+# The intermediate PNGs are deliberately left behind: nothing references them,
+# and they are several times the weight of everything else combined.
+shopt -s nullglob
+copied=0
+for f in "$ROOT"/img/*.svg "$ROOT"/img/*.webp; do
+  cp "$f" "$DEST/"
+  copied=$((copied + 1))
+done
+shopt -u nullglob
+
+if (( copied == 0 )); then
+  echo "Error: no figures were produced in img/ — nothing to publish." >&2
+  exit 1
+fi
+
+echo "Copied $copied figure(s) to docs/public/img/"


### PR DESCRIPTION
Stands up a documentation site at **https://seevee.github.io/weather_alerts_card/**, moving the depth of the docs off the 526-line README.

Implements `plans/docs-pages-site.md` (third revision). The media-hosting half of that plan was already closed by #230/#231/#232, so this is purely "stand up a docs site" — no storefront migration, no `img/` history prune, no Discourse repoint.

## What's here

**`docs/`** — VitePress, eight pages ported from README and AGENTS: overview, getting started, configuration, theming, providers, two pop-up recipes, development.

**`scripts/build-docs-media.sh`** — builds `dist/`, runs the existing `screenshot.js` + `encode-adaptive-svgs.sh` harnesses, stages figures into `docs/public/img/`.

**`.github/workflows/docs.yml`** — Node 20 + Playwright Chromium, `docs:media` → `docs:build` → `upload-pages-artifact` → `deploy-pages`, on push to `main` and `workflow_dispatch`.

**`package.json`** — `vitepress@^1.6.4` plus `docs:dev` / `docs:build` / `docs:preview` / `docs:media`.

## What's deliberately *not* here

- **The README loses nothing.** It stays the HACS storefront — `hacs.json` sets `render_readme: true`, and HACS validation check #5 requires the README to contain images. It gains a Documentation section and nothing else. The duplication with the site is intentional.
- **Docs figures are not committed.** They regenerate deterministically on every Pages build, so `docs/public/img/` and `docs/.vitepress/{dist,cache}/` are gitignored. `img/` still holds exactly the six figures the README embeds. As a side benefit, the `geometry` and `unavailable` figures — which had never been embedded anywhere — now illustrate `showGeometry` and `unavailableBehavior`.
- **The motion demo stays gated** behind `DOCS_MOTION=1`, off by default: it's still being tuned, and leaving it off keeps `ffmpeg`/`ffprobe` off the runner.
- **No card changes.** `src/`, `dist/`, `hacs.json` and the config schema are untouched, as are `build.yml` and `release.yml` — the release path stays Playwright-free.

## Decisions worth flagging

**The recipes lead with the built-in pop-up.** `tap_action: { action: details }` (#224) is genuinely per-alert for every provider and needs no add-ons, and README:130 already says to prefer it — so `recipes/detail-popup.md` comes first and Bubble Card is the alternative. The built-in recipe ships **text-only** for now: the only tuned figure depicts the Bubble sheet, and authoring a second harness scene is a self-contained follow-up once the modal's look is settled.

**`config.mts`, not `config.ts`.** This package is CJS (no `"type": "module"`), so a `.ts` config is loaded as CommonJS and fails on VitePress's ESM-only export — the same reason `rollup.config.mjs` is `.mjs`.

**Markdown references figures as `/img/<name>`**, not `/weather_alerts_card/img/<name>`. VitePress prepends `base` itself; spelling it out doubles it. Verified against the built HTML.

**VitePress pinned to 1.x.** 2.0 requires Node 22+ and all three workflows run Node 20.

## Two gotchas, both documented in AGENTS.md

**`docs:media` must run before `docs:build`** on a fresh clone — VitePress hard-fails on an unresolvable public asset rather than warning, so a bare `docs:build` produces a confusing Rollup error.

**`docs:media` leaves the six tracked storefront figures dirty.** Scene content is deterministic (frozen clock, fixed fixtures), but the encoded bytes aren't portable across Chromium/ImageMagick versions. Pre-existing behaviour of `npm run screenshot:hero`, not new here. Run `git restore img/` after a local run; harmless in CI, which commits nothing.

## Verification

- `npm run build`, `npm run lint`, `npm test` — all green (23 files, 729 tests). No `src/**` changes.
- `npm run docs:media` populates `docs/public/img/` (18 files, 2.6 MB); `npm run docs:build` succeeds (~5s, 4.1 MB artifact).
- Under `npm run docs:preview`, every page and all six figures return 200 under the base path, and all cross-page anchors resolve against real heading ids.
- GitHub Pages is enabled with `build_type: workflow`, and its `html_url` matches the pinned base and the README link.

`docs.yml` cannot run until it lands on `main` (that's what `workflow_dispatch` needs), so the first deploy happens on merge. **The README's docs link 404s until then.**

Assisted-by: Claude:claude-opus-5
