### PR TITLE
docs: qualify the visual-config claim with the YAML-only settings

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ is the same material with more room to breathe, plus per-provider setup detail.
 - **Sort order** — default, onset time, or severity
 - **Severity threshold** — minimum severity to display (unclassified alerts always shown)
 - **Localized UI** — English, French, Spanish, Italian, German, and Simplified Chinese; auto-detected from Home Assistant locale
-- **Visual config** — no YAML editing required
+- **Visual config** — the visual editor covers everyday configuration, including tap actions. A few advanced settings stay YAML-only: custom basemap tiles (`geometryTileUrl` / `geometryTileAttribution`) and the payloads carried by the `perform-action` and `fire-dom-event` tap actions
 
 ## Themes
 


### PR DESCRIPTION
`- **Visual config** — no YAML editing required` was accurate when written and has drifted since. #236 closed the `tap_action` gap that prompted this, but two categories genuinely remain YAML-only, and both are by design rather than oversight:

- **`geometryTileUrl` / `geometryTileAttribution`** — the custom-basemap overrides have no editor control at all.
- **`perform-action` / `fire-dom-event` payloads** — nested `data`/`target`/vendor objects that the new tap-action control deliberately *preserves* rather than edits (D2 of the editor-control plan).

Verified rather than assumed: diffing the 45 keys of `WeatherAlertsCardConfig` against `weather-alerts-card-editor.ts` returns exactly those two uncovered keys.

Docs-only. No source or test changes.

Assisted-by: Claude:claude-opus-5