### PR TITLE
feat(adapters): add a NINA adapter for German civil-protection warnings

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Weather Alerts Card
 
-A custom Home Assistant Lovelace card for displaying weather alerts with severity indicators, progress bars, and expandable details. Supports NWS (US), BoM (Australia), MeteoAlarm (Europe), DWD (Germany), MeteoSwiss (Switzerland), ECCC (Canada), NSW RFS (Australian bushfire), PirateWeather, and CAP Alerts (multi-region).
+A custom Home Assistant Lovelace card for displaying weather alerts with severity indicators, progress bars, and expandable details. Supports NWS (US), BoM (Australia), MeteoAlarm (Europe), DWD (Germany), MeteoSwiss (Switzerland), ECCC (Canada), NINA (German civil protection), NSW RFS (Australian bushfire), PirateWeather, and CAP Alerts (multi-region).
 
 [![Weather Alerts Card](https://raw.githubusercontent.com/seevee/weather_alerts_card/main/img/hero-adaptive.svg)](https://raw.githubusercontent.com/seevee/weather_alerts_card/main/img/hero-light.webp)
 
@@ -15,7 +15,7 @@ is the same material with more room to breathe, plus per-provider setup detail.
 
 ## Features
 
-- **Multi-provider** — NWS (US), BoM (Australia), MeteoAlarm (Europe), DWD (Germany), MeteoSwiss (Switzerland), ECCC (Canada), NSW RFS (Australian bushfire), PirateWeather, and CAP Alerts (multi-region) with auto-detection
+- **Multi-provider** — NWS (US), BoM (Australia), MeteoAlarm (Europe), DWD (Germany), MeteoSwiss (Switzerland), ECCC (Canada), NINA (German civil protection), NSW RFS (Australian bushfire), PirateWeather, and CAP Alerts (multi-region) with auto-detection
 - **Color themes** — severity-based (default), NWS official event colors, MeteoAlarm awareness level colors, or ECCC public-alert colors
 - **Time progress bars** — elapsed/remaining time with relative and absolute timestamps
 - **Alert headlines** — contextual subtitle from provider data, with optional redundancy filtering
@@ -216,7 +216,7 @@ Then click the Download button, and click Reload when prompted.
 | `entities` | — | Additional alert entities to merge (e.g. DWD current + advance) |
 | `device` | — | HA `device_id` — auto-discovers all per-alert sensors under that device and re-discovers as alerts come and go. Currently only the CAP Alerts integration uses this shape. Can be combined with `entity`/`entities` or used on its own. |
 | `sources` | — | Feed `source` attribute values to auto-collect (e.g. `['nsw_rural_fire_service_feed']`). Harvests **every** entity whose `source` attribute matches, re-scanning each render so per-incident entities appear and vanish with the live feed — no volatile `geo_location.*` ids to hand-list. Independent of `provider` (each collected entity still auto-detects its adapter). Can be used on its own or combined with `entity`/`entities`/`device`. |
-| `provider` | auto-detect | `'nws'`, `'bom'`, `'meteoalarm'`, `'dwd'`, `'meteoswiss'`, `'eccc'`, `'nsw_rfs'`, `'pirateweather'`, `'cap'` |
+| `provider` | auto-detect | `'nws'`, `'bom'`, `'meteoalarm'`, `'dwd'`, `'nina'`, `'meteoswiss'`, `'eccc'`, `'nsw_rfs'`, `'pirateweather'`, `'cap'` |
 | `title` | — | Card header title |
 | `zones` | — | Restrict to specific zone codes, matched against each alert's zone list. Populated by CAP Alerts (UGC/SAME/EMMA_ID/NUTS and any other geocode scheme) and BoM (`area_id`, e.g. `NSW_FL049`; fork-dependent — the `safepay/ha_bom_australia` fork emits it). The recommended NWS integration doesn't emit zone codes, so this doesn't apply to it. **Alerts with no matching zone are hidden**, so setting `zones` on a provider that carries none hides everything |
 | `sortOrder` | `'default'` | `'default'`, `'onset'`, `'severity'` |
@@ -332,6 +332,23 @@ entities:
   - sensor.dwd_weather_warnings_advance
 ```
 
+**NINA (German civil protection)**
+
+NINA pre-creates one `binary_sensor` per region per message slot, and the slots sit
+empty until a warning lands. Point the card at the NINA *device* so it picks each slot
+up as it fills and drops it again when it clears:
+
+```yaml
+type: custom:weather-alerts-card
+device: 8f2c1e04a9b7d3651fa0c8e29d47b5a3
+```
+
+Listing slot entities directly works too. An empty slot reads as "no active alerts",
+never as an unavailable source, and the per-slot diagnostic sensors the integration also
+creates (`sensor.*_headline_1`, …) are ignored. See
+[Providers](https://seevee.github.io/weather_alerts_card/providers#nina-german-civil-protection)
+for details — including the HA 2026.11 attribute removal that this support depends on.
+
 **MeteoSwiss (Switzerland)**
 ```yaml
 type: custom:weather-alerts-card
@@ -413,6 +430,7 @@ The card auto-detects the provider from entity attributes. Any integration that 
 | BoM | Australia | [bremor/bureau_of_meteorology](https://github.com/bremor/bureau_of_meteorology), [safepay/ha_bom_australia](https://github.com/safepay/ha_bom_australia) |
 | MeteoAlarm | Europe | Built-in [meteoalarm](https://www.home-assistant.io/integrations/meteoalarm/) |
 | DWD | Germany | Built-in [dwd_weather_warnings](https://www.home-assistant.io/integrations/dwd_weather_warnings/) |
+| NINA | Germany (civil protection) | Built-in [nina](https://www.home-assistant.io/integrations/nina/) — one `binary_sensor` per region per message slot; point the card at the NINA **device** so slots are picked up as warnings land in them. Carries DWD weather, LHP flood and MoWaS/KATWARN/BIWAPP civil-protection messages alike |
 | MeteoSwiss | Switzerland | [izacus/hass-swissweather](https://github.com/izacus/hass-swissweather) — point the card at `sensor.weather_warnings_at_<postcode>` |
 | ECCC | Canada | [seevee/cap_alerts](https://github.com/seevee/cap_alerts) (`provider: eccc`) — the recommended ECCC source; see note below |
 | NSW RFS | Australia (NSW) | Built-in [nsw_rural_fire_service_feed](https://www.home-assistant.io/integrations/nsw_rural_fire_service_feed/) — one `geo_location.*` entity per bushfire/grass-fire/hazard-reduction incident; auto-collect the whole feed with `sources: [nsw_rural_fire_service_feed]` |
@@ -473,6 +491,7 @@ Severity and certainty badges are always localized to your configured language. 
 | BoM | Inferred (parsed from title/type/group) | Absent |
 | MeteoAlarm | Raw (from `awareness_level` or `severity`) | Raw (from `certainty`) |
 | DWD | Raw (from integer `level`) | Absent |
+| NINA | Raw (CAP vocabulary from `severity`) | Absent |
 | MeteoSwiss | Raw (from integer level) | Absent |
 | ECCC | Derived (max of `color`, `type`, `impact`; tilde only when all three absent) | Mapped from `confidence` (High → Likely, Moderate → Possible, Low → Unlikely) |
 | NSW RFS | Raw (from `category` — the Australian Warning System ladder) | Absent |

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -19,7 +19,7 @@ required; they can be combined freely.
 | `entities` | — | Additional alert entities to merge (e.g. DWD current + advance) |
 | `device` | — | HA `device_id` — auto-discovers all per-alert sensors under that device, and re-discovers as alerts come and go. Currently only the CAP Alerts integration uses this shape |
 | `sources` | — | Feed `source` attribute values to auto-collect, e.g. `['nsw_rural_fire_service_feed']` |
-| `provider` | auto-detect | `'nws'`, `'bom'`, `'meteoalarm'`, `'dwd'`, `'meteoswiss'`, `'eccc'`, `'nsw_rfs'`, `'pirateweather'`, `'cap'` |
+| `provider` | auto-detect | `'nws'`, `'bom'`, `'meteoalarm'`, `'dwd'`, `'nina'`, `'meteoswiss'`, `'eccc'`, `'nsw_rfs'`, `'pirateweather'`, `'cap'` |
 
 ### Collecting a whole feed with `sources`
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -21,7 +21,7 @@ hero:
 
 features:
   - title: Multi-provider
-    details: NWS (US), BoM (Australia), MeteoAlarm (Europe), DWD (Germany), MeteoSwiss, ECCC (Canada), NSW RFS, PirateWeather and CAP Alerts — with auto-detection from entity attributes.
+    details: NWS (US), BoM (Australia), MeteoAlarm (Europe), DWD (Germany), NINA (German civil protection), MeteoSwiss, ECCC (Canada), NSW RFS, PirateWeather and CAP Alerts — with auto-detection from entity attributes.
   - title: Color themes
     details: Severity-based by default, or the official NWS event, MeteoAlarm awareness-level, or ECCC public-alert palettes — with per-event contrast correction.
   - title: Time progress bars

--- a/docs/providers.md
+++ b/docs/providers.md
@@ -10,6 +10,7 @@ below lists the ones that are actually tested.
 | BoM | Australia | [bremor/bureau_of_meteorology](https://github.com/bremor/bureau_of_meteorology), [safepay/ha_bom_australia](https://github.com/safepay/ha_bom_australia) |
 | MeteoAlarm | Europe | Built-in [meteoalarm](https://www.home-assistant.io/integrations/meteoalarm/) |
 | DWD | Germany | Built-in [dwd_weather_warnings](https://www.home-assistant.io/integrations/dwd_weather_warnings/) |
+| NINA | Germany (civil protection) | Built-in [nina](https://www.home-assistant.io/integrations/nina/) — see [the note below](#nina-german-civil-protection) |
 | MeteoSwiss | Switzerland | [izacus/hass-swissweather](https://github.com/izacus/hass-swissweather) |
 | ECCC | Canada | [seevee/cap_alerts](https://github.com/seevee/cap_alerts) (`provider: eccc`) — see [below](#canada-eccc-via-cap-alerts) |
 | NSW RFS | Australia (NSW) | Built-in [nsw_rural_fire_service_feed](https://www.home-assistant.io/integrations/nsw_rural_fire_service_feed/) |
@@ -21,8 +22,8 @@ below lists the ones that are actually tested.
 Each provider has an **adapter** that converts raw entity attributes into one normalized
 alert shape, which is all the card UI ever consumes. Detection is by attribute
 signature — NWS by its `Alerts` array, BoM by `warnings`, DWD by `warning_count` plus
-`region_name`, MeteoAlarm by its awareness-level attribute, PirateWeather by its
-attribution string, and so on.
+`region_name`, MeteoAlarm by its awareness-level attribute, NINA by `recommended_actions`
+plus `affected_areas`, PirateWeather by its attribution string, and so on.
 
 Set `provider:` explicitly only if you have a reason to override this.
 
@@ -88,6 +89,55 @@ entity: sensor.dwd_weather_warnings_current
 entities:
   - sensor.dwd_weather_warnings_advance
 ```
+
+### NINA (German civil protection)
+
+NINA is the BBK's national warning app. It carries far more than weather: DWD storm and
+heat warnings, LHP flood warnings, and MoWaS / KATWARN / BIWAPP civil-protection messages
+(evacuations, hazmat, utility outages) all arrive on the same feed.
+
+The integration creates one `binary_sensor` per region **per message slot**, and the slots
+are pre-created empty. Point the card at the NINA **device** rather than hand-listing
+slots — it picks up each slot as a warning lands in it and drops it again when the slot
+clears:
+
+```yaml
+type: custom:weather-alerts-card
+device: 8f2c1e04a9b7d3651fa0c8e29d47b5a3
+```
+
+Listing the slot entities directly works too, and is what you want if you only care about
+the first slot or two:
+
+```yaml
+type: custom:weather-alerts-card
+entity: binary_sensor.mittelfranken_warnung_1
+entities:
+  - binary_sensor.mittelfranken_warnung_2
+  - binary_sensor.mittelfranken_warnung_3
+```
+
+An empty slot reports `off` with no attributes, which the card reads as "no active alerts"
+— an all-quiet NINA region is never flagged as an unavailable source. The per-slot
+diagnostic sensors the integration also creates (`sensor.*_headline_1`,
+`sensor.*_severity_1`, …) hold one value each and are ignored.
+
+Severity is the CAP vocabulary verbatim, so badges render without the inferred-value
+tilde, and real `start` / `expires` timestamps drive the progress bar. Row titles are
+lifted out of the DWD headline template — "Amtliche WARNUNG vor extremer HITZE" titles
+the row "Extremer Hitze" and keeps the full headline underneath. Headlines from the
+non-DWD senders are free prose and pass through unchanged. NINA publishes no geometry, so
+`showGeometry` has nothing to draw.
+
+::: warning Attribute removal in HA 2026.11
+Everything the card reads apart from `id` is deprecated on the NINA binary sensor and
+scheduled for removal in Home Assistant 2026.11
+([core#161882](https://github.com/home-assistant/core/pull/161882)). The replacement is
+the per-field diagnostic sensors plus a `nina.get_details` action; `description` and
+`recommended_actions` got no sensor at all. Card support as described here is correct
+through HA 2026.10 and will need reworking after that — tracked in
+[#234](https://github.com/seevee/weather_alerts_card/issues/234).
+:::
 
 ### MeteoSwiss (Switzerland)
 
@@ -206,6 +256,7 @@ badges reflect real provider data.
 | BoM | Inferred (parsed from title/type/group) | Absent |
 | MeteoAlarm | Raw (from `awareness_level` or `severity`) | Raw (from `certainty`) |
 | DWD | Raw (from integer `level`) | Absent |
+| NINA | Raw (CAP vocabulary from `severity`) | Absent |
 | MeteoSwiss | Raw (from integer level) | Absent |
 | ECCC | Derived (max of `color`, `type`, `impact`; tilde only when all three are absent) | Mapped from `confidence` (High → Likely, Moderate → Possible, Low → Unlikely) |
 | NSW RFS | Raw (from `category`) | Absent |

--- a/src/adapters/index.ts
+++ b/src/adapters/index.ts
@@ -8,10 +8,11 @@ import { PirateWeatherAdapter } from './pirateweather';
 import { CapAdapter } from './cap';
 import { EcccAdapter } from './eccc';
 import { NswRfsAdapter } from './nsw_rfs';
+import { NinaAdapter } from './nina';
 
 // CAP comes first so its `incident_platform_version` marker wins detection
 // over any upstream-shaped attributes that the integration may surface.
-const adapters: AlertAdapter[] = [new CapAdapter(), new NwsAdapter(), new BomAdapter(), new NswRfsAdapter(), new DwdAdapter(), new MeteoSwissAdapter(), new MeteoAlarmAdapter(), new EcccAdapter(), new PirateWeatherAdapter()];
+const adapters: AlertAdapter[] = [new CapAdapter(), new NwsAdapter(), new BomAdapter(), new NswRfsAdapter(), new NinaAdapter(), new DwdAdapter(), new MeteoSwissAdapter(), new MeteoAlarmAdapter(), new EcccAdapter(), new PirateWeatherAdapter()];
 
 /** Name-based heuristic patterns for likely alert entities. */
 export const ENTITY_NAME_PATTERNS: RegExp[] = [
@@ -27,6 +28,12 @@ export const ENTITY_NAME_PATTERNS: RegExp[] = [
   // siblings don't contain `cap_alert_` (singular + underscore), so they're
   // excluded.
   /^sensor\..*cap_alert_/i,
+  // NINA warning slots: `binary_sensor.<region>_warning_<n>`, slugged from the
+  // entity name HA translated at creation time (German instances get
+  // `..._warnung_1`). An idle slot publishes no attributes for `canHandleAny`
+  // to recognise, so without this pattern the editor's picker would hide the
+  // very entities a user needs to select *before* a warning ever lands.
+  /^binary_sensor\..*_warn(?:ing|ung)_\d+$/i,
 ];
 
 /** Returns true if any adapter recognises the given attributes. */

--- a/src/adapters/nina.ts
+++ b/src/adapters/nina.ts
@@ -1,0 +1,124 @@
+import { AlertAdapter, AlertProvider, AlertSeverity, WeatherAlert } from '../types';
+import { normalizeSeverity, parseTimestamp } from '../utils';
+
+// NINA (BBK, Germany) surfaces one `binary_sensor` per region *per message
+// slot* (CONF_MESSAGE_SLOTS). An occupied slot carries the whole warning as
+// flat attributes; an empty slot is `off` with `extra_state_attributes == {}`,
+// so `canHandle` rejects it and the card sees "no active alerts" rather than a
+// degraded source. The per-slot `sensor.*` siblings (headline, sender,
+// severity, …) are single-value diagnostics with no alert attributes of their
+// own, so device-mode collection skips them for the same reason.
+//
+// DEPRECATION: home-assistant/core#161882 marked every attribute below except
+// `id` for removal in HA 2026.11, with the per-field diagnostic sensors as the
+// replacement and `nina.get_details` (core#166125) covering `description` and
+// `recommended_actions`, which got no sensor. Reassembling an alert from that
+// shape needs an 8-entity fan-in plus a service call from the render path, so
+// it is a different adapter, not a tweak to this one. This one is correct for
+// every HA release up to and including 2026.10.
+
+// NINA is a Germany-only feed and its message bodies are German, so the
+// synthesised attribution line is labelled in German to match the text it is
+// appended to (same principle as the English `Label: value` lines NSW RFS
+// synthesises for its English feed).
+const SENDER_LABEL = 'Herausgeber';
+
+// DWD stamps a fixed template onto the headline of every weather message it
+// pushes through NINA ("Amtliche WARNUNG vor extremer HITZE"). Stripping the
+// boilerplate leaves the hazard itself for the row title, while the untouched
+// headline stays on as the secondary line. Anchored, so the free-text headlines
+// of the non-DWD sources NINA aggregates (LHP flood, MoWaS, KATWARN, BIWAPP)
+// fall through verbatim.
+const DWD_HEADLINE_PREFIX = /^(?:amtliche\s+)?(?:(?:extreme\s+)?(?:unwetter)?warnung|vorabinformation)\s+(?:vor\s+)?/i;
+
+// DWD shouts the hazard in the headline ("extremer HITZE"); the card carries
+// emphasis in the severity badge, so the extracted title is normalised to
+// sentence-ish case. Only applied when the template actually matched — a
+// pass-through headline is another sender's prose and is left alone.
+function titleCase(s: string): string {
+  return s.replace(/\w\S*/g, w => w.charAt(0).toUpperCase() + w.slice(1).toLowerCase());
+}
+
+function eventFromHeadline(headline: string): string {
+  if (!DWD_HEADLINE_PREFIX.test(headline)) return headline;
+  const stripped = headline.replace(DWD_HEADLINE_PREFIX, '').trim();
+  return stripped ? titleCase(stripped) : headline;
+}
+
+// `sender` has no first-class WeatherAlert home but names the issuing authority,
+// which is the thing that separates a DWD heat warning from a district
+// evacuation order. Double-newline separation survives reflowAlertText, which
+// merges single-newline lines within a paragraph.
+function buildDescription(description: string, sender: string): string {
+  if (!sender) return description;
+  const attribution = `${SENDER_LABEL}: ${sender}`;
+  return description ? `${description}\n\n${attribution}` : attribution;
+}
+
+export class NinaAdapter implements AlertAdapter {
+  provider: AlertProvider = 'nina';
+
+  canHandle(attributes: Record<string, unknown>): boolean {
+    // `recommended_actions` + `affected_areas` collide with no other adapter's
+    // signature, and both keys are written unconditionally for an occupied slot
+    // (empty *values* are normal — BBK messages often carry no advice).
+    return typeof attributes['recommended_actions'] === 'string'
+      && typeof attributes['affected_areas'] === 'string'
+      && typeof attributes['id'] === 'string';
+  }
+
+  parseAlerts(attributes: Record<string, unknown>): WeatherAlert[] {
+    if (!this.canHandle(attributes)) return [];
+
+    const id = str(attributes['id']);
+    if (!id) return [];
+
+    const headline = str(attributes['headline']);
+    const rawSeverity = str(attributes['severity']);
+    const severity = normalizeSeverity(rawSeverity) as AlertSeverity;
+
+    const sentTs = parseTimestamp(str(attributes['sent']));
+    // `start` and `expires` are written as '' when the message omits them, so
+    // an open-ended warning lands on endsTs 0 → the card's honest "ongoing".
+    const onsetTs = parseTimestamp(str(attributes['start'])) || sentTs;
+    const endsTs = parseTimestamp(str(attributes['expires']));
+
+    return [{
+      id,
+      event: eventFromHeadline(headline) || 'Warnung',
+      severity,
+      severityLabel: rawSeverity
+        ? rawSeverity.charAt(0).toUpperCase() + rawSeverity.slice(1).toLowerCase()
+        : severity.charAt(0).toUpperCase() + severity.slice(1),
+      certainty: '',
+      urgency: '',
+      sentTs,
+      onsetTs,
+      endsTs,
+      description: buildDescription(str(attributes['description']), str(attributes['sender'])),
+      instruction: str(attributes['recommended_actions']),
+      url: httpUrl(str(attributes['web'])),
+      headline,
+      // Comma-joined municipality names, truncated by the integration
+      // ("… und 1144 weitere."). Prose, not codes — nothing to feed `zones`.
+      areaDesc: str(attributes['affected_areas']),
+      zones: [],
+      eventCode: '',
+      provider: 'nina',
+      phase: '',
+      // The integration substitutes the literal 'Unknown' when the message
+      // carries no severity, so the value is always provider-supplied — never
+      // something this adapter derived.
+      severityInferred: false,
+      certaintyInferred: false,
+    }];
+  }
+}
+
+function str(v: unknown): string {
+  return typeof v === 'string' ? v : '';
+}
+
+function httpUrl(v: string): string {
+  return v.startsWith('http://') || v.startsWith('https://') ? v : '';
+}

--- a/src/translations/de.ts
+++ b/src/translations/de.ts
@@ -72,6 +72,7 @@ export const de: TranslationMap = {
   'editor.provider_meteoalarm': 'MeteoAlarm (Europa)',
   'editor.provider_pirateweather': 'PirateWeather',
   'editor.provider_dwd': 'DWD (Deutschland)',
+  'editor.provider_nina': 'NINA (Deutschland, Bevölkerungsschutz)',
   'editor.provider_meteoswiss': 'MeteoSwiss (Schweiz)',
   'editor.provider_eccc': 'ECCC (Kanada)',
   'editor.provider_nsw_rfs': 'NSW RFS (Australien)',

--- a/src/translations/en.ts
+++ b/src/translations/en.ts
@@ -72,6 +72,7 @@ export const en: TranslationMap = {
   'editor.provider_meteoalarm': 'MeteoAlarm (Europe)',
   'editor.provider_pirateweather': 'PirateWeather',
   'editor.provider_dwd': 'DWD (Germany)',
+  'editor.provider_nina': 'NINA (Germany, civil protection)',
   'editor.provider_meteoswiss': 'MeteoSwiss (Switzerland)',
   'editor.provider_eccc': 'ECCC (Canada)',
   'editor.provider_nsw_rfs': 'NSW RFS (Australia)',

--- a/src/translations/es.ts
+++ b/src/translations/es.ts
@@ -72,6 +72,7 @@ export const es: TranslationMap = {
   'editor.provider_meteoalarm': 'MeteoAlarm (Europa)',
   'editor.provider_pirateweather': 'PirateWeather',
   'editor.provider_dwd': 'DWD (Alemania)',
+  'editor.provider_nina': 'NINA (Alemania, protección civil)',
   'editor.provider_meteoswiss': 'MeteoSwiss (Suiza)',
   'editor.provider_eccc': 'ECCC (Canadá)',
   'editor.provider_nsw_rfs': 'NSW RFS (Australia)',

--- a/src/translations/fr.ts
+++ b/src/translations/fr.ts
@@ -72,6 +72,7 @@ export const fr: TranslationMap = {
   'editor.provider_meteoalarm': 'MeteoAlarm (Europe)',
   'editor.provider_pirateweather': 'PirateWeather',
   'editor.provider_dwd': 'DWD (Allemagne)',
+  'editor.provider_nina': 'NINA (Allemagne, protection civile)',
   'editor.provider_meteoswiss': 'MeteoSwiss (Suisse)',
   'editor.provider_eccc': 'ECCC (Canada)',
   'editor.provider_nsw_rfs': 'NSW RFS (Australie)',

--- a/src/translations/it.ts
+++ b/src/translations/it.ts
@@ -72,6 +72,7 @@ export const it: TranslationMap = {
   'editor.provider_meteoalarm': 'MeteoAlarm (Europa)',
   'editor.provider_pirateweather': 'PirateWeather',
   'editor.provider_dwd': 'DWD (Germania)',
+  'editor.provider_nina': 'NINA (Germania, protezione civile)',
   'editor.provider_meteoswiss': 'MeteoSwiss (Svizzera)',
   'editor.provider_eccc': 'ECCC (Canada)',
   'editor.provider_nsw_rfs': 'NSW RFS (Australia)',

--- a/src/translations/zh-Hans.ts
+++ b/src/translations/zh-Hans.ts
@@ -72,6 +72,7 @@ export const zhHans: TranslationMap = {
   'editor.provider_meteoalarm': 'MeteoAlarm（欧洲）',
   'editor.provider_pirateweather': 'PirateWeather',
   'editor.provider_dwd': 'DWD（德国）',
+  'editor.provider_nina': 'NINA（德国民防预警）',
   'editor.provider_meteoswiss': 'MeteoSwiss（瑞士）',
   'editor.provider_eccc': 'ECCC（加拿大）',
   'editor.provider_nsw_rfs': 'NSW RFS（澳大利亚）',

--- a/src/types.ts
+++ b/src/types.ts
@@ -81,7 +81,7 @@ export interface EntityRegistryDisplayEntry {
 }
 
 export type AlertSeverity = 'extreme' | 'severe' | 'moderate' | 'minor' | 'unknown';
-export type AlertProvider = 'nws' | 'bom' | 'meteoalarm' | 'pirateweather' | 'dwd' | 'cap' | 'eccc' | 'meteoswiss' | 'nsw_rfs';
+export type AlertProvider = 'nws' | 'bom' | 'meteoalarm' | 'pirateweather' | 'dwd' | 'cap' | 'eccc' | 'meteoswiss' | 'nsw_rfs' | 'nina';
 export type ContrastMode = 'off' | 'subtle' | 'strict';
 
 // Progress-bar decoration (pattern) applied to a temporal phase's fill. Direction

--- a/src/weather-alerts-card-editor.ts
+++ b/src/weather-alerts-card-editor.ts
@@ -1014,6 +1014,7 @@ export class WeatherAlertsCardEditor extends LitElement {
           <ha-dropdown-item value="bom">${t('editor.provider_bom', lang)}</ha-dropdown-item>
           <ha-dropdown-item value="meteoalarm">${t('editor.provider_meteoalarm', lang)}</ha-dropdown-item>
           <ha-dropdown-item value="dwd">${t('editor.provider_dwd', lang)}</ha-dropdown-item>
+          <ha-dropdown-item value="nina">${t('editor.provider_nina', lang)}</ha-dropdown-item>
           <ha-dropdown-item value="meteoswiss">${t('editor.provider_meteoswiss', lang)}</ha-dropdown-item>
           <ha-dropdown-item value="eccc">${t('editor.provider_eccc', lang)}</ha-dropdown-item>
           <ha-dropdown-item value="nsw_rfs">${t('editor.provider_nsw_rfs', lang)}</ha-dropdown-item>

--- a/src/weather-alerts-card.ts
+++ b/src/weather-alerts-card.ts
@@ -83,6 +83,7 @@ const PROVIDER_LABELS: Record<string, string> = {
   pirateweather: 'Pirate Weather',
   cap: 'CAP',
   nsw_rfs: 'NSW RFS',
+  nina: 'NINA',
 };
 
 const PROVIDER_SHORT: Record<string, string> = {
@@ -95,6 +96,7 @@ const PROVIDER_SHORT: Record<string, string> = {
   pirateweather: 'PW',
   cap: 'CAP',
   nsw_rfs: 'RFS',
+  nina: 'NINA',
 };
 
 // Entity name patterns are now in adapters/index.ts (ENTITY_NAME_PATTERNS).

--- a/tests/adapters/nina.test.ts
+++ b/tests/adapters/nina.test.ts
@@ -1,0 +1,231 @@
+import { describe, it, expect } from 'vitest';
+import { NinaAdapter } from '../../src/adapters/nina';
+import { getDisplayHeadline, getWeatherIcon, parseTimestamp } from '../../src/utils';
+
+// Verbatim attributes of an active `binary_sensor` warning slot, contributed by
+// @duczz on #234 (region name redacted upstream). Real DWD heat warning routed
+// through NINA; `affected_areas` is truncated by the integration exactly as
+// shown.
+const SAMPLE: Record<string, unknown> = {
+  headline: 'Amtliche WARNUNG vor extremer HITZE',
+  description: 'Am Dienstag wird eine extreme Wärmebelastung erwartet.',
+  sender: 'Zentrum für Medizin-Meteorologische Forschung',
+  severity: 'Severe',
+  recommended_actions: 'Hitzebelastung kann für den menschlichen Körper gefährlich werden und zu einer Vielzahl von gesundheitlichen Problemen führen. Vermeiden Sie nach Möglichkeit die Hitze, trinken Sie ausreichend Wasser und halten Sie die Innenräume kühl.',
+  affected_areas: 'gemeindefreies Gebiet Zerzabelshofer Forst, gemeindefreies Gebiet Winkelhaid, Stadt Roßwein, Gemeinde Rossau, Stadt Weismain, Gemeinde Striegistal und 1144 weitere.',
+  web: 'https://dwd.de/warnungen',
+  id: 'dwd.2.49.0.0.276.0.DWD.PVW.1785741840000.081e027b-8b91-4e98-8c8d-ecbca01b9952.MUL',
+  sent: '2026-08-03T09:23:29+02:00',
+  start: '2026-08-03T09:24:00+02:00',
+  expires: '2026-08-04T19:00:00+02:00',
+  device_class: 'safety',
+  friendly_name: 'xxxx Warnung 1',
+};
+
+function makeWarning(overrides: Record<string, unknown> = {}): Record<string, unknown> {
+  return { ...SAMPLE, ...overrides };
+}
+
+describe('NinaAdapter', () => {
+  const adapter = new NinaAdapter();
+
+  describe('canHandle', () => {
+    it('accepts the contributed sample', () => {
+      expect(adapter.canHandle(SAMPLE)).toBe(true);
+    });
+
+    it('accepts a warning with empty recommended_actions', () => {
+      expect(adapter.canHandle(makeWarning({ recommended_actions: '' }))).toBe(true);
+    });
+
+    it('rejects an idle slot (empty attributes)', () => {
+      // The integration returns {} from extra_state_attributes when is_on is
+      // False — this is the guard that keeps an idle NINA region reading as
+      // "no active alerts" rather than a degraded source.
+      expect(adapter.canHandle({})).toBe(false);
+    });
+
+    it('rejects a slot missing affected_areas', () => {
+      const attrs = makeWarning();
+      delete attrs['affected_areas'];
+      expect(adapter.canHandle(attrs)).toBe(false);
+    });
+
+    it('rejects a slot missing recommended_actions', () => {
+      const attrs = makeWarning();
+      delete attrs['recommended_actions'];
+      expect(adapter.canHandle(attrs)).toBe(false);
+    });
+
+    it('rejects a NINA per-field diagnostic sensor', () => {
+      // sensor.<region>_headline_1 and friends sit on the same device but hold
+      // a single value with no alert attributes; device-mode collection must
+      // skip them.
+      expect(adapter.canHandle({ friendly_name: 'xxxx Headline 1' })).toBe(false);
+    });
+
+    it('rejects a CAP Alerts entity', () => {
+      expect(adapter.canHandle({
+        incident_platform_version: '1.0',
+        id: 'urn:oid:2.49.0.1.276.0',
+        instruction: 'Take shelter',
+        area_desc: 'Berlin',
+      })).toBe(false);
+    });
+  });
+
+  describe('parseAlerts', () => {
+    it('returns nothing for an idle slot', () => {
+      expect(adapter.parseAlerts({})).toEqual([]);
+    });
+
+    it('returns nothing when id is empty', () => {
+      expect(adapter.parseAlerts(makeWarning({ id: '' }))).toEqual([]);
+    });
+
+    it('normalizes the contributed sample', () => {
+      const [alert] = adapter.parseAlerts(SAMPLE);
+      expect(alert.id).toBe(SAMPLE['id']);
+      expect(alert.provider).toBe('nina');
+      expect(alert.severity).toBe('severe');
+      expect(alert.severityLabel).toBe('Severe');
+      expect(alert.severityInferred).toBe(false);
+      expect(alert.certainty).toBe('');
+      expect(alert.urgency).toBe('');
+      expect(alert.eventCode).toBe('');
+      expect(alert.phase).toBe('');
+      expect(alert.zones).toEqual([]);
+      expect(alert.url).toBe('https://dwd.de/warnungen');
+      expect(alert.areaDesc).toBe(SAMPLE['affected_areas']);
+      expect(alert.instruction).toBe(SAMPLE['recommended_actions']);
+    });
+
+    it('maps sent/start/expires onto the progress timestamps', () => {
+      const [alert] = adapter.parseAlerts(SAMPLE);
+      expect(alert.sentTs).toBe(parseTimestamp('2026-08-03T09:23:29+02:00'));
+      expect(alert.onsetTs).toBe(parseTimestamp('2026-08-03T09:24:00+02:00'));
+      expect(alert.endsTs).toBe(parseTimestamp('2026-08-04T19:00:00+02:00'));
+      expect(alert.endsTs).toBeGreaterThan(alert.onsetTs);
+    });
+
+    it('falls back to sent when start is empty', () => {
+      // The integration writes '' (not null) when the message omits start.
+      const [alert] = adapter.parseAlerts(makeWarning({ start: '' }));
+      expect(alert.onsetTs).toBe(alert.sentTs);
+      expect(alert.onsetTs).toBeGreaterThan(0);
+    });
+
+    it('leaves endsTs at 0 when expires is empty', () => {
+      // 0 → hasEndTime false → the card's honest "ongoing", no fabricated bar.
+      const [alert] = adapter.parseAlerts(makeWarning({ expires: '' }));
+      expect(alert.endsTs).toBe(0);
+    });
+
+    it('appends the sender as an attribution paragraph', () => {
+      const [alert] = adapter.parseAlerts(SAMPLE);
+      expect(alert.description).toBe(
+        'Am Dienstag wird eine extreme Wärmebelastung erwartet.'
+        + '\n\nHerausgeber: Zentrum für Medizin-Meteorologische Forschung',
+      );
+    });
+
+    it('emits the attribution alone when the message has no description', () => {
+      const [alert] = adapter.parseAlerts(makeWarning({ description: '' }));
+      expect(alert.description).toBe('Herausgeber: Zentrum für Medizin-Meteorologische Forschung');
+    });
+
+    it('leaves the description untouched when sender is empty', () => {
+      const [alert] = adapter.parseAlerts(makeWarning({ sender: '' }));
+      expect(alert.description).toBe('Am Dienstag wird eine extreme Wärmebelastung erwartet.');
+    });
+
+    it('drops a non-http web value', () => {
+      expect(adapter.parseAlerts(makeWarning({ web: '' }))[0].url).toBe('');
+      expect(adapter.parseAlerts(makeWarning({ web: 'javascript:alert(1)' }))[0].url).toBe('');
+    });
+
+    it('maps every NINA severity onto the card tiers', () => {
+      const cases: [string, string, string][] = [
+        ['Extreme', 'extreme', 'Extreme'],
+        ['Severe', 'severe', 'Severe'],
+        ['Moderate', 'moderate', 'Moderate'],
+        ['Minor', 'minor', 'Minor'],
+        ['Unknown', 'unknown', 'Unknown'],
+      ];
+      for (const [raw, severity, label] of cases) {
+        const [alert] = adapter.parseAlerts(makeWarning({ severity: raw }));
+        expect(alert.severity).toBe(severity);
+        expect(alert.severityLabel).toBe(label);
+        // The integration substitutes 'Unknown' itself, so nothing here is
+        // adapter-inferred — the badge must never render the tilde.
+        expect(alert.severityInferred).toBe(false);
+      }
+    });
+  });
+
+  describe('event derivation', () => {
+    it('strips the DWD headline template down to the hazard', () => {
+      const [alert] = adapter.parseAlerts(SAMPLE);
+      expect(alert.event).toBe('Extremer Hitze');
+      expect(alert.headline).toBe('Amtliche WARNUNG vor extremer HITZE');
+    });
+
+    it('keeps the full headline as the secondary line', () => {
+      // event and headline differ, so the smart-dedup filter must not swallow
+      // the headline row.
+      const [alert] = adapter.parseAlerts(SAMPLE);
+      expect(getDisplayHeadline(alert)).toBe('Amtliche WARNUNG vor extremer HITZE');
+    });
+
+    it.each([
+      ['Amtliche UNWETTERWARNUNG vor SCHWEREM GEWITTER', 'Schwerem Gewitter'],
+      ['Amtliche EXTREME UNWETTERWARNUNG vor ORKANBÖEN', 'Orkanböen'],
+      ['Amtliche WARNUNG vor GLATTEIS', 'Glatteis'],
+      ['Vorabinformation SCHWERES GEWITTER', 'Schweres Gewitter'],
+      ['Warnung vor Waldbrandgefahr', 'Waldbrandgefahr'],
+    ])('strips %s', (headline, expected) => {
+      expect(adapter.parseAlerts(makeWarning({ headline }))[0].event).toBe(expected);
+    });
+
+    it('passes non-DWD sender headlines through verbatim', () => {
+      // NINA also carries LHP, MoWaS, KATWARN and BIWAPP messages, whose
+      // headlines are free prose with no template to strip.
+      const headline = 'Bombenfund in der Innenstadt - Evakuierung';
+      const [alert] = adapter.parseAlerts(makeWarning({ headline }));
+      expect(alert.event).toBe(headline);
+      // event === headline, so the headline row collapses instead of repeating.
+      expect(getDisplayHeadline(alert)).toBe('');
+    });
+
+    it('keeps the headline when the template leaves nothing behind', () => {
+      const [alert] = adapter.parseAlerts(makeWarning({ headline: 'Amtliche WARNUNG' }));
+      expect(alert.event).toBe('Amtliche WARNUNG');
+    });
+
+    it('falls back to a generic event when the headline is empty', () => {
+      const [alert] = adapter.parseAlerts(makeWarning({ headline: '' }));
+      expect(alert.event).toBe('Warnung');
+    });
+  });
+
+  describe('icon resolution', () => {
+    it.each([
+      ['Amtliche WARNUNG vor extremer HITZE', 'mdi:weather-sunny-alert'],
+      ['Amtliche UNWETTERWARNUNG vor SCHWEREM GEWITTER', 'mdi:weather-lightning'],
+      ['Amtliche WARNUNG vor GLATTEIS', 'mdi:snowflake'],
+      ['Amtliche WARNUNG vor HOCHWASSER', 'mdi:home-flood'],
+      ['Amtliche WARNUNG vor ORKANBÖEN', 'mdi:weather-windy'],
+    ])('resolves %s via the German keyword dictionary', (headline, icon) => {
+      // No providerIcon is set — the derived event has to hit the dictionary's
+      // German keywords, which the DWD adapter already seeded.
+      const [alert] = adapter.parseAlerts(makeWarning({ headline }));
+      expect(alert.providerIcon).toBeUndefined();
+      expect(getWeatherIcon(alert.iconHint || alert.event)).toBe(icon);
+    });
+
+    it('falls back to the generic icon for a civil-protection message', () => {
+      const [alert] = adapter.parseAlerts(makeWarning({ headline: 'Bombenfund - Evakuierung' }));
+      expect(getWeatherIcon(alert.event)).toBe('mdi:alert-circle-outline');
+    });
+  });
+});

--- a/tests/adapters/registry.test.ts
+++ b/tests/adapters/registry.test.ts
@@ -149,6 +149,21 @@ describe('getAdapter', () => {
     expect(adapter.provider).toBe('nsw_rfs');
   });
 
+  it('returns NINA adapter for explicit nina provider', () => {
+    const adapter = getAdapter('nina', {});
+    expect(adapter.provider).toBe('nina');
+  });
+
+  it('auto-detects NINA from recommended_actions + affected_areas + id', () => {
+    const adapter = getAdapter(undefined, {
+      headline: 'Amtliche WARNUNG vor extremer HITZE',
+      recommended_actions: 'Trinken Sie ausreichend Wasser.',
+      affected_areas: 'Stadt Roßwein, Gemeinde Rossau und 1144 weitere.',
+      id: 'dwd.2.49.0.0.276.0.DWD.PVW.1785741840000.081e027b.MUL',
+    });
+    expect(adapter.provider).toBe('nina');
+  });
+
   it('defaults to NWS when attributes are ambiguous', () => {
     const adapter = getAdapter(undefined, {});
     expect(adapter.provider).toBe('nws');
@@ -212,6 +227,20 @@ describe('canHandleAny', () => {
     })).toBe(true);
   });
 
+  it('returns true for NINA attributes', () => {
+    expect(canHandleAny({
+      recommended_actions: 'Trinken Sie ausreichend Wasser.',
+      affected_areas: 'Stadt Roßwein und 1144 weitere.',
+      id: 'dwd.2.49.0.0.276.0.DWD.PVW.1785741840000.081e027b.MUL',
+    })).toBe(true);
+  });
+
+  it('returns false for an idle NINA warning slot', () => {
+    // Empty attributes must stay unrecognised so device-mode collection reads
+    // an all-idle NINA region as "no active alerts", not as a dark source.
+    expect(canHandleAny({})).toBe(false);
+  });
+
   it('returns false for a generic geo_location quake entity', () => {
     expect(canHandleAny({ external_id: 'us7000abcd', magnitude: 5.1 })).toBe(false);
   });
@@ -239,6 +268,21 @@ describe('ENTITY_NAME_PATTERNS', () => {
 
   it('matches MeteoAlarm binary sensor', () => {
     expect(matches('binary_sensor.meteoalarm_wind')).toBe(true);
+  });
+
+  it('matches NINA warning slots in both name languages', () => {
+    // HA slugs the entity_id from the name it translated at creation time, so
+    // the slot reads `warning_1` on an English instance and `warnung_1` on a
+    // German one. Idle slots publish no attributes, so this pattern is the only
+    // thing keeping them selectable in the editor before a warning lands.
+    expect(matches('binary_sensor.mittelfranken_warning_1')).toBe(true);
+    expect(matches('binary_sensor.mittelfranken_warnung_1')).toBe(true);
+    expect(matches('binary_sensor.stadt_und_landkreis_hof_warnung_10')).toBe(true);
+  });
+
+  it('does not match the NINA per-field diagnostic sensors', () => {
+    expect(matches('sensor.mittelfranken_headline_1')).toBe(false);
+    expect(matches('sensor.mittelfranken_severity_1')).toBe(false);
   });
 
   it('does not match unrelated sensors', () => {


### PR DESCRIPTION
## Summary

Adds a `nina` adapter for the built-in [NINA](https://www.home-assistant.io/integrations/nina/)
integration (BBK — German federal civil protection), closing the data gap on #234.
@duczz sent the attributes of a live warning slot over the forum DMs, which settled all
four open design questions from that thread.

**Read the caveat below before merging — this has a known ~3-month shelf life, and the
better long-term route is probably not this branch at all.**

## Why this may not be worth merging

Every attribute this adapter reads apart from `id` is deprecated on the NINA binary
sensor and scheduled for removal in **HA 2026.11**
([core#161882](https://github.com/home-assistant/core/pull/161882), merged 2026-04-01).
That is roughly three releases out. The replacement is not a drop-in:

- The per-field diagnostic sensors cover 8 fields only, and `sent` / `start` / `expires`
  ship `entity_registry_enabled_default=False` — **disabled by default**.
- `affected_areas` becomes the truncated *short* form.
- **`description` and `recommended_actions` got no sensor at all.** They are reachable
  only via the `nina.get_details` action
  ([core#166125](https://github.com/home-assistant/core/pull/166125),
  `SupportsResponse.ONLY`).

So after 2026.11 a NINA alert cannot be assembled from entity state alone — it needs an
8-entity fan-in *plus* a service call from the render path, which collides with the
card's render-purity invariant. This is the same wall we hit on the core
`environment_canada` integration (`get_alerts` action), and the reason the card doesn't
route to it.

**The likely real answer is cap_alerts, not a rework of this adapter.** BBK's own API
*is* CAP, verified against the live feed 2026-08-03:

- `warnung.bund.de/api31/warnings/{id}.json` returns a CAP 1.2 document in JSON —
  `identifier` / `sender` / `sent` / `status` / `msgType` / `scope`, plus `info[]` with
  `event`, `severity`, `certainty`, `urgency`, `headline`, `description`, `instruction`,
  `eventCode`, `area[]`.
- The live DWD heat warning matching @duczz's sample carries `certainty: Likely`,
  `urgency: Immediate`, `event: EXTREME HITZE`, `msgType: Alert` and an `eventCode`
  including `GROUP: HEAT` — **all discarded by the HA integration**. The CAP route gains
  a real certainty badge, an event code for filtering and a `phase` value that the
  attribute path never had, plus the untruncated area list.
- `warnung.bund.de/api31/warnings/{id}.geojson` returns a real `FeatureCollection` of
  lon/lat `Polygon`s. The "geometry tier: none" noted on #234 is a limit of the
  *integration*, not the feed.

Under the routing standard in #205, NINA qualified as "thin card adapter because a good
HA integration exists". 2026.11 removes the *good*, and BBK-via-cap_alerts wins on every
axis — the GDACS pattern. Tracked in seevee/cap_alerts#66.

Merging is still defensible: it works today and through HA 2026.10, and for the
MoWaS / KATWARN / BIWAPP civil-protection half of the feed there is no other HA path at
all. But it is a deliberately time-boxed adapter, not a durable one.

## What the sample settled

| Question from #234 | Answer |
| --- | --- |
| Discovery | `device:` mode works unchanged — NINA registers one device per region, and `resolveDeviceAlertEntities` re-resolves each render so slots appear as they fill |
| Slot filtering | An idle slot is `off` with `extra_state_attributes == {}` → `canHandle` false. The degraded-source check only fires on `unavailable`/`unknown`, so a quiet region reads "no active alerts", never a dark source. No new machinery |
| Ignoring the per-field sensors | Excluded by the same `canHandle` filter — no explicit carve-out needed |
| Detection signature | `recommended_actions` + `affected_areas` + `id`; collides with none of the nine existing adapters |

Severity is the CAP vocabulary verbatim, so badges render without the inferred tilde, and
real `start` / `expires` drive the progress bar. An omitted `expires` arrives as `''`,
landing on `endsTs: 0` → the card's honest "ongoing" rather than a fabricated bar.

## Changes

- `src/adapters/nina.ts` — new adapter; registered in `src/adapters/index.ts`,
  `'nina'` added to `AlertProvider`.
- Row titles are lifted out of the DWD headline template: "Amtliche WARNUNG vor extremer
  HITZE" titles the row **"Extremer Hitze"** and keeps the untouched headline as the
  secondary line. The pattern is anchored, so free prose from the other senders NINA
  aggregates (LHP, MoWaS, KATWARN, BIWAPP) falls through verbatim and the smart-dedup
  filter collapses the then-identical headline row. No `providerIcon`: the German
  keywords the DWD adapter seeded into the icon dictionary already resolve the derived
  titles.
- `sender` names the issuing authority — the thing separating a DWD heat warning from a
  district evacuation order — and has no first-class `WeatherAlert` home, so it is
  appended to the description as a labelled paragraph. Labelled in German to match the
  text it joins, on the same principle as NSW RFS's English `Label: value` lines.
- `binary_sensor.*_warn(ing|ung)_<n>` name pattern — idle slots publish no attributes for
  `canHandleAny` to recognise, so without it the editor's picker would hide the very
  entities a user needs to select *before* a warning ever lands. Both spellings because
  HA slugs the entity_id from the name it translated at creation time.
- Provider label + short code, editor dropdown entry, `editor.provider_nina` across all
  six locales.
- Docs: README provider tables and example, `docs/providers.md` (new section with the
  deprecation callout), `docs/configuration.md`, `docs/index.md`.
- Tests: `tests/adapters/nina.test.ts` (new, built on @duczz's verbatim payload) plus
  registry coverage for detection, the idle-slot guard and the name pattern.

## Test Plan

- [x] `npm run lint` passes
- [x] `npm run build` passes
- [x] `npm test` — 785 passing (43 new)
- [x] `npm run docs:build` passes
- [ ] Tested against a real NINA install — **not done**, and not doable from here: no
      German civil-protection warning was active locally, and there is no NINA instance
      to point a card at. The entity-id shape is inferred from the `warning` translation
      key plus the German `friendly_name` in @duczz's sample rather than observed, which
      is the one guess in this branch. If this merges and reaches an alpha, confirming
      `device:` mode against a live region is the thing to check first.

Assisted-by: Claude:claude-opus-5
