### PR TITLE
fix(scripts): stop prereleases from rewriting the changelog

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,98 +1,24 @@
 # Changelog
 
-## 3.3.0-alpha.4 — 2026-08-05
-
-### Added
-- Add a NINA adapter for German civil-protection warnings (#240) (7f82d11…)
-
-### Documentation
-- Fix the unusable translation-only PR template link (#242) (1b1b257…)
-
-### Maintenance
-- Add a translation request issue template (#243) (bef87ff…)
-
-## 3.3.0-alpha.3 — 2026-08-03
-
-### Added
-- Add a tap_action control to the visual editor (#236) (d168c74…)
-
-### Documentation
-- Qualify the visual-config claim with the YAML-only settings (#237) (61753bd…)
-
-## 3.3.0-alpha.2 — 2026-08-03
-
-### Added
-- Configurable per-phase progress decoration + icon-ring border (#219) (1084a0e…)
-- Bubble-style whole-row progress fill (progressFill: background) (#220) (567770b…)
-- Configurable tap_action per alert row (replaces inline-expand) (#221) (bbeff49…)
-- Per-alert detail pop-up (tap_action: { action: details }) (#224) (8c04042…)
-- Add Chinese translations (#225) (1677d9a…)
-
-### Documentation
-- Commit the tap_action motion capture prototype (#228) (082f2fd…)
-- Add a VitePress documentation site on GitHub Pages (#233) (6c8b9d6…)
-
-### Maintenance
-- Remove local slash commands now tracked in dotfiles (#218) (fc5b721…)
-- Split locales per-file and add parity guard (#223) (c1f3ba9…)
-- Enforce LF line endings via .gitattributes (#226) (4433462…)
-- Add provider request template, translation PR ergonomics, remove CODEOWNERS (#227) (80fdcfe…)
-- Attach storefront figures as release assets (#229) (1fe4be8…)
-- Untrack generated figures, keep only the six README references (#230) (e13eca4…)
-- Pick the image codec per figure instead of PNG for everything (#231) (7b55a4d…)
-- Drop the release-asset media upload from #229 (#232) (7dc51cd…)
-
-## 3.3.0-alpha.1 — 2026-07-20
-
-### Added
-- Transparency-by-default + --wac-* surface token API (#215) (#216) (1a4505c…)
-
-### Documentation
-- Surface broken-source badge + mini-map, correct zone-filtering scope (#214) (a770055…)
-
-## 3.2.0-alpha.6 — 2026-07-13
-
-### Added
-- Degraded-source indicator for partial multi-entity breakage (#201) (#211) (25a7e5f…)
-
-## 3.2.0-alpha.5 — 2026-07-12
-
-### Added
-- Add NSW RFS bushfire alert provider (#178) (#208) (971572d…)
-
-### Documentation
-- Document the sources feed auto-collection config key (#209) (13b43a3…)
-
-## 3.2.0-alpha.4 — 2026-07-12
-
-### Fixed
-- Use warning_links for source link; render open-ended warnings as Ongoing (#186) (#203) (08b037f…)
-
-## 3.2.0-alpha.3 — 2026-07-04
-
-### Added
-- Opt-in unavailableBehavior for broken alert sensors (#187) (#200) (78308de…)
-
-## 3.2.0-alpha.2 — 2026-07-03
-
-### Added
-- Read geocodes container into zone filtering (#197) (f01a28c…)
-
-### Fixed
-- Downlevel bundle to ES2019 for old Android WebViews (#194) (#198) (647692a…)
-
-## 3.2.0-alpha.1 — 2026-07-03
+## 3.2.0 — 2026-07-14
 
 ### Added
 - Add MeteoSwiss adapter for Switzerland (#186) (#192) (514464d…)
+- Read geocodes container into zone filtering (#197) (f01a28c…)
+- Opt-in unavailableBehavior for broken alert sensors (#187) (#200) (78308de…)
+- Add NSW RFS bushfire alert provider (#178) (#208) (971572d…)
+- Degraded-source indicator for partial multi-entity breakage (#201) (#211) (25a7e5f…)
 
 ### Documentation
 - Recommend CAP Alerts as the only ECCC source (#191) (f0f5704…)
 - Add AI-assisted contribution policy (tool, not author) (#195) (9ecdc7f…)
+- Document the sources feed auto-collection config key (#209) (13b43a3…)
 
 ### Fixed
 - Render affected-area geometry as a map basemap (#185) (56ac2d9…)
 - Render alerts from sensors reporting state "unknown" (#188) (b4da355…)
+- Downlevel bundle to ES2019 for old Android WebViews (#194) (#198) (647692a…)
+- Use warning_links for source link; render open-ended warnings as Ongoing (#186) (#203) (08b037f…)
 
 ### test
 - Fix flaky device-mode dismissal test via suite-wide teardown (#193) (a5f8b9f…)
@@ -112,7 +38,7 @@
 ### Fixed
 - Normalize hyphen/slash separators in getWeatherIcon (#176) (51d61f4…)
 
-## 3.0.1-alpha.1 — 2026-05-25
+## 3.0.1 — 2026-05-25
 
 ### Documentation
 - Add v3 migration guide and fix community thread URL (#169) (04a5c12…)
@@ -121,36 +47,22 @@
 - Suppress URN identifiers from source link (#170) (becd13a…)
 - Address audit findings (perf, render purity, filter safety, robustness) (#172) (30d09f9…)
 
-## 3.0.0-alpha.4 — 2026-05-12
-
-### Added
-- Pass through provider-supplied MDI icon from CAP adapter (#162) (067793c…)
-- Dismiss trigger + style options, pointer drag-to-dismiss (#163) (7f935b9…)
-
-### Maintenance
-- Dependency update pass — TypeScript 6, drop custom-card-helpers (#164) (fad8dcd…)
-- Add ECCC color theme column to themes screenshot (#165) (1426d80…)
-
-## 3.0.0-alpha.3 — 2026-05-12
-
-### Added
-- Add ECCC adapter for Environment Canada alerts (#160) (0d41495…)
-
-## 3.0.0-alpha.2 — 2026-04-26
-
-### Added
-- Add CAP Alerts adapter with device auto-discovery (#158) (f0673bb…)
-
-## 3.0.0-alpha.1 — 2026-04-24
+## 3.0.0 — 2026-05-12
 
 ### Added
 - WCAG contrast-aware colors (off|subtle|strict) + knockouts (#150) (74e59e2…)
 - Add opt-in browser-local alert dismissal with undo (#155) (1b109b0…)
+- Add CAP Alerts adapter with device auto-discovery (#158) (f0673bb…)
+- Add ECCC adapter for Environment Canada alerts (#160) (0d41495…)
+- Pass through provider-supplied MDI icon from CAP adapter (#162) (067793c…)
+- Dismiss trigger + style options, pointer drag-to-dismiss (#163) (7f935b9…)
 
 ### Maintenance
 - Use host networking with explicit DNS (#153) (1a12260…)
 - Split meteoalarm areaDesc on commas (#154) (cb1bb0d…)
 - Remove v1 backwards-compatibility shims ahead of v3 (#156) (2c83ae7…)
+- Dependency update pass — TypeScript 6, drop custom-card-helpers (#164) (fad8dcd…)
+- Add ECCC color theme column to themes screenshot (#165) (1426d80…)
 
 ## 2.11.1 — 2026-04-18
 
@@ -162,45 +74,33 @@
 
 ## 2.11.0 — 2026-04-17
 
+### Added
+- Add expandDetails option to render details inline without toggle (#137) (c2909b4…)
+- Add cross-provider alert deduplication and provider label (#140) (1b1df86…)
+
 ### Documentation
 - README polish + dedup screenshot provider labels (#145) (302b890…)
-
-## 2.11.0-alpha.3 — 2026-04-17
 
 ### Fixed
 - Default showProvider to false to avoid breaking existing setups (#142) (7d696d7…)
 
-## 2.11.0-alpha.2 — 2026-04-17
+## 2.10.0 — 2026-04-08
 
 ### Added
-- Add cross-provider alert deduplication and provider label (#140) (1b1df86…)
-
-## 2.11.0-alpha.1 — 2026-04-11
-
-### Added
-- Add expandDetails option to render details inline without toggle (#137) (c2909b4…)
-
-## 2.10.0-alpha.2 — 2026-04-07
-
-### Added
+- Support multiple entities in a single card (#129) (13361a9…)
 - Show sample data toggle with nudge when no alerts active (#133) (f7648d1…)
 
 ### Changed
 - Inject card version from package.json at build time (#132) (ec7a8e2…)
 
-### Maintenance
-- Update dependencies and fix rollup build (#131) (24248ab…)
-
-## 2.10.0-alpha.1 — 2026-04-06
-
-### Added
-- Support multiple entities in a single card (#129) (13361a9…)
-
 ### Fixed
 - Preserve NWS period forecast lines and make release script resumable (#126) (b1be730…)
 - Show hint when no provider entities are found (#128) (8ae9c61…)
 
-## 2.9.0-alpha.1 — 2026-04-04
+### Maintenance
+- Update dependencies and fix rollup build (#131) (24248ab…)
+
+## 2.9.0 — 2026-04-04
 
 ### Added
 - Add reformatText option to strip NWS hard line wraps (#119) (060a752…)
@@ -214,7 +114,7 @@
 - Resolve HACS validate race condition and Node.js 20 deprecation (#118) (1ab4b6d…)
 - Preserve expanded alert state across config changes (#120) (55c71df…)
 
-## 2.8.1-alpha.1 — 2026-04-01
+## 2.8.1 — 2026-04-02
 
 ### Fixed
 - Use English awareness_type for MeteoAlarm icon lookup (#115) (33235a0…)
@@ -238,31 +138,21 @@
 ## 2.7.0 — 2026-03-30
 
 ### Added
+- Add hideNoAlerts option to suppress empty-state banner (#97) (7f49d58…)
+- Add configurable font size with fontSize option and --wac-scale CSS property (#101) (cdca6bf…)
 - Add severity and certainty data purity indicators (#103) (4ea15ff…)
 
 ### Maintenance
 - Revert cliff.toml to enforce conventional commits via PR titles (74bae4c…)
 
-## 2.7.0-alpha.3 — 2026-03-29
-
-### Added
-- Add configurable font size with fontSize option and --wac-scale CSS property (#101) (cdca6bf…)
-
-## 2.7.0-alpha.1 — 2026-03-29
-
-### Added
-- Add hideNoAlerts option to suppress empty-state banner (#97) (7f49d58…)
-
 ## 2.6.0 — 2026-03-28
-
-### Documentation
-- Refresh README with config table and theme showcase (#95) (daac370…)
-
-## 2.6.0-alpha.1 — 2026-03-28
 
 ### Added
 - Filter entity picker to compatible alert entities (#92) (947f85b…)
 - Integrate progress bar into compact layout (#86) (440fecc…)
+
+### Documentation
+- Refresh README with config table and theme showcase (#95) (daac370…)
 
 ### Maintenance
 - Rework testing-zones script for diversity scoring (#91) (2803344…)
@@ -282,67 +172,41 @@
 ## 2.5.0 — 2026-03-26
 
 ### Added
-- Rename headline config option to deduplicateHeadlines (#80) (258dc40…)
-- Add MeteoAlarm awareness level color theme (#81) (a01e52d…)
-
-## 2.5.0-alpha.2 — 2026-03-26
-
-### Added
+- Add excludeEventCodes config option to filter out unwanted alerts (#72) (d4c79c0…)
 - Display alert headlines with smart redundancy filtering (#76) (2718014…)
 - Add showSourceLink config option to hide source links (#75) (#77) (7ccad91…)
-
-## 2.5.0-alpha.1 — 2026-03-26
-
-### Added
-- Add excludeEventCodes config option to filter out unwanted alerts (#72) (d4c79c0…)
+- Rename headline config option to deduplicateHeadlines (#80) (258dc40…)
+- Add MeteoAlarm awareness level color theme (#81) (a01e52d…)
 
 ## 2.4.0 — 2026-03-26
 
 ### Added
+- Internationalize card UI and editor for en/fr/es (#61) (96dc505…)
+- Icon-box temporal state + progress label hierarchy (#63) (5bb4650…)
 - Add custom notes and new-contributor flags to publish script (#70) (1551b1b…)
 
 ### Documentation
+- Add missing eventCodes and timezone options to README (#60) (ec120ce…)
 - Update installation instructions in README.md (#67) (5db57c1…)
 
 ### Fixed
+- Make publish script idempotent for safe re-runs (#64) (c5816a8…)
 - Add checkout and build steps to HACS validation workflow (#68) (a4f43ff…)
 - Run HACS validation on main push only, not PRs (#69) (6292274…)
-
-## 2.4.0-alpha.2 — 2026-03-25
-
-### Added
-- Icon-box temporal state + progress label hierarchy (#63) (5bb4650…)
-
-### Fixed
-- Make publish script idempotent for safe re-runs (#64) (c5816a8…)
-
-## 2.4.0-alpha.1 — 2026-03-25
-
-### Added
-- Internationalize card UI and editor for en/fr/es (#61) (96dc505…)
-
-### Documentation
-- Add missing eventCodes and timezone options to README (#60) (ec120ce…)
 
 ## 2.3.0 — 2026-03-24
 
 ### Added
+- Show preview with placeholder alerts in card picker (#53) (ab6084e…)
+- Add browser timezone option for traveling users (#55) (8316432…)
 - Add NWS event code support and filtering (#57) (d6b2eb9…)
 - Expand weather icon coverage for more event types (#58) (8894a23…)
 
 ### Fixed
+- Use NWS color-triggering keywords in placeholder alert names (861880c…)
 - Update repo links for rename to weather_alerts_card (e2a2ad0…)
 - Use old repo name in HACS link until default store updates (6b2e975…)
 - Remove HACS button until default store reflects rename (d17bfb4…)
-
-## 2.3.0-alpha.1 — 2026-03-23
-
-### Added
-- Show preview with placeholder alerts in card picker (#53) (ab6084e…)
-- Add browser timezone option for traveling users (#55) (8316432…)
-
-### Fixed
-- Use NWS color-triggering keywords in placeholder alert names (861880c…)
 
 ### Maintenance
 - Regenerate adaptive hero SVG from 2x DPR PNGs (8e97cf5…)
@@ -364,53 +228,37 @@
 
 ## 2.1.0 — 2026-03-15
 
-### Documentation
-- Add adaptive hero svg (54b91a2…)
-- Add adaptive hero svg generator script (68c867d…)
-
-## 2.1.0-alpha.2 — 2026-03-15
+### Added
+- Deduplicate alerts across zones (#37) (4332648…)
 
 ### Documentation
 - Add theme-aware hero images for README (#39) (34246fb…)
 - Expand last compact alert in hero screenshots (#40) (4749946…)
-
-### Maintenance
-- Skip release commits from changelog (ea7d32f…)
-
-## 2.1.0-alpha.1 — 2026-03-15
-
-### Added
-- Deduplicate alerts across zones (#37) (4332648…)
+- Add adaptive hero svg (54b91a2…)
+- Add adaptive hero svg generator script (68c867d…)
 
 ### Fixed
 - Put migration notice before changelog in release notes (0ed28bd…)
 
+### Maintenance
+- Skip release commits from changelog (ea7d32f…)
+
 ## 2.0.0 — 2026-03-15
-
-### Fixed
-- Add version headers to changelog and fix cliff config path (#32) (58e19e1…)
-- Scope release notes to correct version range (#33) (bb30959…)
-- Add migration notice to GA release notes and clarify HACS resource path (#35) (3687b1c…)
-
-## 2.0.0-alpha.2 — 2026-03-14
-
-### Added
-- Add styled console log with card name and version at load time (#30) (c406500…)
-
-### Fixed
-- Use npx to run git-cliff in publish script (dcefd1e…)
-- Remove extra blank lines between changelog entries (#29) (4cdabe2…)
-
-## 2.0.0-alpha.1 — 2026-03-14
 
 ### Added
 - Add MeteoAlarm (Europe) adapter (#11) (6046982…)
 - Rename to "Weather Alerts Card" for multi-provider support (#25) (d302d15…)
 - Display affected area description on alert cards (#27) (89adc5e…)
+- Add styled console log with card name and version at load time (#30) (c406500…)
 
 ### Fixed
 - Remove push trigger from validate workflow to prevent duplicate runs (#23) (48fe454…)
 - Align NwsAlert type with nws_alerts integration fields (#26) (832cbee…)
+- Use npx to run git-cliff in publish script (dcefd1e…)
+- Remove extra blank lines between changelog entries (#29) (4cdabe2…)
+- Add version headers to changelog and fix cliff config path (#32) (58e19e1…)
+- Scope release notes to correct version range (#33) (bb30959…)
+- Add migration notice to GA release notes and clarify HACS resource path (#35) (3687b1c…)
 
 ### Maintenance
 - Streamline agent skills and dev workflow (#22) (f6fbc20…)
@@ -429,23 +277,17 @@
 
 ## 1.9.0 — 2026-03-09
 
-### Fixed
-- Use absolute URLs for README images so they display in HACS (#9) (a8007af…)
-
-## 1.9.0-alpha.3 — 2026-03-06
-
-### Added
-- Support ha_bom_australia integration with area_id zone filtering (#7) (36f3d30…)
-
-## 1.9.0-alpha.1 — 2026-03-06
-
 ### Added
 - Add automated screenshot utility for README images (65ffbd3…)
 - Add multi-provider adapter pattern with BoM support (#1) (#4) (320fd0f…)
+- Support ha_bom_australia integration with area_id zone filtering (#7) (36f3d30…)
 
 ### Documentation
 - Readme img udates, repo janitorial duties (412b879…)
 - Update README for official HACS procedure (126196b…)
+
+### Fixed
+- Use absolute URLs for README images so they display in HACS (#9) (a8007af…)
 
 ### Maintenance
 - CI hardening, repo hygiene, and test scaffolding (#2) (bc1a46c…)

--- a/scripts/release.sh
+++ b/scripts/release.sh
@@ -149,14 +149,30 @@ else
 fi
 
 # -------------------------
-# Determine cliff flags for note generation
-# GA releases ignore prerelease tags to collapse alpha/beta/rc into one section
+# Determine cliff flags
+#
+# Two surfaces want two different tag sets, so they get two flag sets:
+#
+#   Release notes describe what is new since the last tag of any kind, so a
+#   prerelease needs prerelease tags visible or the notes restate the whole
+#   cycle. A GA release ignores them to collapse its alphas into one section.
+#
+#   CHANGELOG.md is the permanent record and only ever lists GA releases, so
+#   a prerelease must not touch it at all. Sharing one flag set meant an alpha
+#   run regenerated the file over the full history WITH prerelease tags, which
+#   rewrote every past GA section into its constituent alphas — 3.2.0 dropped
+#   out of the file entirely — until the next GA release put it back.
 # -------------------------
 
-CLIFF_FLAGS=()
+STABLE_TAGS=(--tag-pattern "^v[0-9]+\.[0-9]+\.[0-9]+$")
 
-if [[ ! "$VERSION" =~ -(alpha|beta|rc)\. ]]; then
-  CLIFF_FLAGS+=(--tag-pattern "^v[0-9]+\.[0-9]+\.[0-9]+$")
+IS_PRERELEASE=false
+NOTES_FLAGS=()
+
+if [[ "$VERSION" =~ -(alpha|beta|rc)\. ]]; then
+  IS_PRERELEASE=true
+else
+  NOTES_FLAGS+=("${STABLE_TAGS[@]}")
 fi
 
 # -------------------------
@@ -171,7 +187,7 @@ if [ "$DRY_RUN" = true ]; then
   npx git-cliff \
     --config cliff.toml \
     --tag "v$VERSION" \
-    "${CLIFF_FLAGS[@]}" \
+    "${NOTES_FLAGS[@]}" \
     --unreleased \
     --strip header \
     "$BASE_REF"
@@ -212,7 +228,15 @@ fi
 # Generate changelog
 # -------------------------
 
-npx git-cliff --config cliff.toml --tag "v$VERSION" "${CLIFF_FLAGS[@]}" --output CHANGELOG.md
+# A prerelease contributes no section: its commits land in the GA section that
+# eventually ships, so the file stays byte-identical to its last GA shape.
+# git-cliff has no inverse of `--unreleased`, so regenerating without a --tag
+# would emit the pending commits as a headless block above the newest release.
+if [ "$IS_PRERELEASE" = true ]; then
+  echo "Prerelease: leaving CHANGELOG.md at its last GA shape"
+else
+  npx git-cliff --config cliff.toml --tag "v$VERSION" "${STABLE_TAGS[@]}" --output CHANGELOG.md
+fi
 
 git add CHANGELOG.md package.json package-lock.json img/
 
@@ -240,7 +264,7 @@ fi
 NOTES=$(npx git-cliff \
   --config cliff.toml \
   --tag "v$VERSION" \
-  "${CLIFF_FLAGS[@]}" \
+  "${NOTES_FLAGS[@]}" \
   --unreleased \
   --strip header)
 


### PR DESCRIPTION
Same bug as seevee/cap_alerts#110, found there first and then traced back here. Both repos share this release script, and neither had solved it.

`scripts/release.sh` computed one `CLIFF_FLAGS` array and handed it to both the GitHub release notes and the `CHANGELOG.md` regeneration, and those two surfaces want different tag sets. Notes describe what's new since the last tag of any kind, so a prerelease genuinely needs prerelease tags visible. The changelog file is the permanent record and lists GA releases only. Sharing the array meant every alpha run rewrote the whole file with prerelease tags matched, shattering each past GA section into its constituent alphas.

**This repo is currently sitting in the broken state**, and has been since 3.3.0-alpha.1. `CHANGELOG.md` on main has 68 headings, nearly all of them alphas, and **`## 3.2.0` isn't in the file at all** — even though the file at the `v3.2.0` tag itself had it. With prerelease tags matched, the only commit in 3.2.0's range is `chore: release v3.2.0`, which `cliff.toml` skips, so the section came out empty and git-cliff dropped it. A shipped GA release with no changelog entry.

## Fix

Split the flags in two. Notes keep today's behavior exactly. The changelog is regenerated only on a GA release, always with the stable tag pattern.

**Why skip the regeneration rather than always pass the stable pattern.** git-cliff has no inverse of `--unreleased`, so with the stable pattern but no `--tag`, the pending commits render through the group loop while the template's `{% if version %}` guard suppresses their heading. You get a headless block of bullets above the newest release. A prerelease has nothing to add to a GA-only record, so the correct write is no write.

## The changelog rebuild

`CHANGELOG.md` here is rebuilt as of `v3.2.0` — the shape the 3.2.0 release run should have produced. Generated from a worktree checked out at that tag so nothing later leaks in, rather than hand-edited.

Two things to expect:

- **`## 3.2.0` is a heading again**, with real content. Worth noting this means the empty-section problem needs no separate fix: under the stable pattern, 3.2.0's range runs from `v3.1.0` and picks up every alpha's commits, so it can't come out empty. The skip rule in `cliff.toml` is left alone.
- **The `3.3.0-alpha.*` sections drop out.** That's the design, not a loss: their commits reappear under `## 3.3.0` when it ships. It does mean the changelog says nothing about 3.3.0 until GA, which is the same contract cap_alerts has always run.

Net: 68 headings down to 38, all of them real releases.

## Note on CI

Actions is in a major outage (started 15:22Z), so this will sit without a run. The diff is `scripts/release.sh` and `CHANGELOG.md` only — no `src/`, and nothing reads the changelog at build time.

Assisted-by: Claude:claude-opus-5
