### PR TITLE
docs: list Dutch in the localized-UI blurbs

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ is the same material with more room to breathe, plus per-provider setup detail.
 - **Broken-source safety badge** — when a configured sensor goes unavailable/unknown, a degraded indicator names the broken source instead of silently showing "no alerts" (a dead feed is never treated as proof of safety) (`unavailableBehavior`)
 - **Sort order** — default, onset time, or severity
 - **Severity threshold** — minimum severity to display (unclassified alerts always shown)
-- **Localized UI** — English, French, Spanish, Italian, German, and Simplified Chinese; auto-detected from Home Assistant locale
+- **Localized UI** — English, French, Spanish, Italian, German, Dutch, and Simplified Chinese; auto-detected from Home Assistant locale
 - **Visual config** — the visual editor covers everyday configuration, including tap actions. A few advanced settings stay YAML-only: custom basemap tiles (`geometryTileUrl` / `geometryTileAttribution`) and the payloads carried by the `perform-action` and `fire-dom-event` tap actions
 
 ## Themes

--- a/docs/index.md
+++ b/docs/index.md
@@ -35,7 +35,7 @@ features:
   - title: Themeable surfaces
     details: A small, stable set of --wac-* CSS custom properties for backgrounds, borders, corners and shadows. No card config needed.
   - title: Localized UI
-    details: English, French, Spanish, Italian, German and Simplified Chinese, auto-detected from your Home Assistant locale.
+    details: English, French, Spanish, Italian, German, Dutch and Simplified Chinese, auto-detected from your Home Assistant locale.
   - title: Visual config
     details: Every option is available in the visual editor. No YAML editing required.
 ---


### PR DESCRIPTION
#247 added `nl` to the translations registry but missed the two places that enumerate shipped locales for readers: the README feature list and the docs-site landing page.

Both now read "English, French, Spanish, Italian, German, Dutch and Simplified Chinese", matching the order in `src/translations/index.ts`.

Assisted-by: Claude:claude-opus-5