### PR TITLE
fix(unavailable): stop an unpressed button from darkening a device

### DIFF
--- a/src/weather-alerts-card.ts
+++ b/src/weather-alerts-card.ts
@@ -99,6 +99,14 @@ const PROVIDER_SHORT: Record<string, string> = {
   nina: 'NINA',
 };
 
+// Domains whose entities issue a command rather than report data, so they are
+// skipped when judging whether a device has gone dark (_brokenSources). A
+// button sits at state `unknown` until the first time it is pressed — its
+// healthy resting state, not a fault — and cap_alerts keeps its refresh button
+// off the coordinator precisely so a failing update cannot take it away. Left
+// in, an unpressed button marks every zero-alert device unavailable.
+const COMMAND_DOMAINS = new Set(['button', 'scene', 'script', 'input_button']);
+
 // Entity name patterns are now in adapters/index.ts (ENTITY_NAME_PATTERNS).
 // Registry helpers (resolveDeviceAlertEntities, deviceHasAnyEntity,
 // subscribeEntityRegistry) live in ./registry and are re-exported above.
@@ -1032,6 +1040,9 @@ export class WeatherAlertsCard extends LitElement {
   //     all-clear. Named from the device registry (see _deviceName) so 'message'
   //     mode can show *which* source; falls back to a generic singular only when
   //     the registry has no name for it.
+  //
+  // Command entities are excluded from the device scan (see COMMAND_DOMAINS):
+  // they carry no data, and their idle state is `unknown`.
   private _brokenSources(): BrokenSource[] {
     if (!this.hass) return [];
     const sources: BrokenSource[] = [];
@@ -1048,6 +1059,7 @@ export class WeatherAlertsCard extends LitElement {
       let hasParseable = false;
       let hasErrored = false;
       for (const id of deviceEntityIds(this.hass, this._config.device, this._registryEntries)) {
+        if (COMMAND_DOMAINS.has(id.split('.', 1)[0])) continue;
         const e = this.hass.states[id];
         if (!e) continue;
         const parses = getAdapter(this._config.provider, e.attributes).parseAlerts(e.attributes).length > 0;

--- a/tests/device-mode.test.ts
+++ b/tests/device-mode.test.ts
@@ -711,4 +711,60 @@ describe('WeatherAlertsCard degraded signal in device mode (#201 device gap)', (
     expect(hasEl(card, '.no-alerts-caveat')).toBe(false);
     cleanup();
   });
+
+  // A never-pressed refresh button reads `unknown` — its idle state, not a
+  // fault. Counting it as an error state made every zero-alert cap_alerts
+  // device look dark, which a GDACS entry (globally filtered, so usually at
+  // zero) hit on essentially every render.
+  const BUTTON_ID = 'button.cap_alerts_meteoalarm_refresh';
+
+  it('an unpressed refresh button does not make an idle device dark', async () => {
+    const hass = makeHass(
+      [entry(COUNT_ID), entry(UPDATED_ID), entry(BUTTON_ID)],
+      {
+        [COUNT_ID]: { state: '0', attributes: { friendly_name: 'Alert count' } },
+        [UPDATED_ID]: { state: '2026-04-26T01:55:00+00:00', attributes: {} },
+        [BUTTON_ID]: { state: 'unknown', attributes: { friendly_name: 'Refresh' } },
+      },
+      { [DEVICE]: { id: DEVICE, name: DEVICE_NAME } },
+    );
+    const { card, cleanup } = await mountCard(
+      { type: 'custom:weather-alerts-card', device: DEVICE } as WeatherAlertsCardConfig,
+      hass,
+    );
+    expect(hasEl(card, '.no-alerts')).toBe(true);
+    expect(hasEl(card, '.no-alerts-caveat')).toBe(false);
+    cleanup();
+  });
+
+  it('_brokenSources ignores command entities on an idle device', () => {
+    const card = makeCard();
+    card.setConfig({ type: 'custom:weather-alerts-card', device: DEVICE } as WeatherAlertsCardConfig);
+    card.hass = makeHass(
+      [entry(COUNT_ID), entry(BUTTON_ID)],
+      {
+        [COUNT_ID]: { state: '0', attributes: { friendly_name: 'Alert count' } },
+        [BUTTON_ID]: { state: 'unknown', attributes: { friendly_name: 'Refresh' } },
+      },
+      { [DEVICE]: { id: DEVICE, name: DEVICE_NAME } },
+    );
+    expect(card._brokenSources()).toEqual([]);
+  });
+
+  it('a genuinely dark device is still flagged when it also has a button', () => {
+    // The exclusion must not swallow the real signal: the data entities are
+    // unavailable here, and the button's presence changes nothing.
+    const card = makeCard();
+    card.setConfig({ type: 'custom:weather-alerts-card', device: DEVICE } as WeatherAlertsCardConfig);
+    card.hass = makeHass(
+      [entry(COUNT_ID), entry(UPDATED_ID), entry(BUTTON_ID)],
+      {
+        [COUNT_ID]: { state: 'unavailable', attributes: restored() },
+        [UPDATED_ID]: { state: 'unavailable', attributes: restored() },
+        [BUTTON_ID]: { state: 'unknown', attributes: { friendly_name: 'Refresh' } },
+      },
+      { [DEVICE]: { id: DEVICE, name: DEVICE_NAME } },
+    );
+    expect(card._brokenSources()).toEqual([{ name: DEVICE_NAME }]);
+  });
 });


### PR DESCRIPTION
The card reports a healthy cap_alerts device as unavailable whenever it has no alerts.

Device mode reads the *unfiltered* device entities to spot a dark source (#211), and that part is right: an unavailable source loses its alert attributes, so the `canHandle`-filtered list stops seeing it. What got swept in alongside is the refresh button, and a button nobody has pressed sits at state `unknown`. That's its idle state, not a fault.

At zero alerts nothing on the device parses as an alert — count and last_updated never carry alert attributes — so `hasParseable` is false by definition. The unpressed button alone then trips `hasErrored` and the device gets flagged. Every cap_alerts device hits this the moment it goes quiet, unless someone has pressed its refresh button at some point in its life.

I found it on a GDACS entry, where it's the steady state rather than an edge case: that feed is global and filtered down to one location, so zero alerts is normal, and a fresh entry has never had its button pressed. Straight off my dev instance, mid-poll and completely healthy:

```
button.cap_alerts_gdacs_refresh      => 'unknown'
sensor.cap_alerts_gdacs_alert_count  => '0'
sensor.cap_alerts_gdacs_last_updated => '2026-08-08T22:40:11+00:00'
```

A WMO entry sitting at zero on the same instance shows it too, so this isn't about GDACS. GDACS is just the first source quiet enough to make it the normal case.

## Fix

Skip command domains in the availability scan. cap_alerts keeps its refresh button off the coordinator on purpose, so that a failing update can't take the button away exactly when it's most useful — which also means the button has no availability signal to contribute in either direction. `scene`, `script` and `input_button` come along with it: same idle-`unknown` shape, same absence of data to judge a source by.

The data entities are untouched. count and last_updated going `unavailable` on a failed coordinator update, the ECCC stream binary sensor, and per-alert sensors that lose their attributes all still read as dark.

## Verification

Three tests in `tests/device-mode.test.ts`: an unpressed button on an idle device renders no caveat, `_brokenSources` returns nothing for it, and a genuinely dark device is still named when it happens to have a button. That last one is the guard against over-excluding — it passes with or without the fix, by design. The first two fail without it, which I checked by stashing the source change and re-running.

Full suite 802 passing, `tsc --noEmit` clean. No manual browser pass yet; the live GDACS device is still sitting in the failing state, so that's easy to confirm once this is built.

Assisted-by: Claude:claude-opus-5
