### PR TITLE
docs(agents): name the dev container weather-alerts-card-ha

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -129,7 +129,7 @@ The card needs the `sensor.nws_alerts_alerts` entity which comes from the [NWS A
 
 1. **Install HACS** (one-time):
    ```bash
-   docker exec -it nws-alerts-card-ha bash
+   docker exec -it weather-alerts-card-ha bash
    wget -O - https://get.hacs.xyz | bash -
    ```
    Restart HA (Settings → System → Restart), then add HACS as an integration: Settings → Devices & Services → Add Integration → search "HACS" → follow the GitHub device code authorization flow. The HACS sidebar entry appears after this step.


### PR DESCRIPTION
The compose file renamed the container along with the repo, AGENTS.md still told the docker exec step to attach to nws-alerts-card-ha. One-line fix.

Assisted-by: Claude:claude-fable-5-1